### PR TITLE
UI/4 admin procurement requests filter and details

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -123,7 +123,7 @@ function App() {
         }
       />
       <Route
-          path="/admin-procurement-bids/:id"
+          path="/admin-procurement-requests/:requestId/bid/:bidId"
           element={
           <AdminRoute>
               <BidLogs/>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import ProcurementPreview from "./pages/ProcurementPreview.jsx";
 import SellerFavorites from "./pages/SellerFavorites.jsx";
 import EditProcurementForm from "./pages/EditProcurementRequestBuyer.jsx";
 import AdminProcurementDashboard from "./pages/AdminProcurementRequests.jsx";
+import AdminProcurementPreview from "./pages/AdminProcurementPreview.jsx";
 
 function App() {
   return (
@@ -109,6 +110,14 @@ function App() {
         element={
           <AdminRoute>
             <AdminProcurementDashboard />
+          </AdminRoute>
+        }
+      />
+      <Route
+        path="/admin-procurement-requests/:id"
+        element={
+          <AdminRoute>
+              <AdminProcurementPreview />
           </AdminRoute>
         }
       />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import BuyerProcurementForm from "./pages/BuyerProcurementForm.jsx";
 import ProcurementPreview from "./pages/ProcurementPreview.jsx";
 import SellerFavorites from "./pages/SellerFavorites.jsx";
 import EditProcurementForm from "./pages/EditProcurementRequestBuyer.jsx";
+import AdminProcurementDashboard from "./pages/AdminProcurementRequests.jsx";
 
 function App() {
   return (
@@ -100,6 +101,14 @@ function App() {
         element={
           <AdminRoute>
             <AdminDashboard />
+          </AdminRoute>
+        }
+      />
+      <Route
+        path="/admin-procurement-requests"
+        element={
+          <AdminRoute>
+            <AdminProcurementDashboard />
           </AdminRoute>
         }
       />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import SellerFavorites from "./pages/SellerFavorites.jsx";
 import EditProcurementForm from "./pages/EditProcurementRequestBuyer.jsx";
 import AdminProcurementDashboard from "./pages/AdminProcurementRequests.jsx";
 import AdminProcurementPreview from "./pages/AdminProcurementPreview.jsx";
+import BidLogs from "./pages/BidLogs.jsx";
 
 function App() {
   return (
@@ -120,6 +121,13 @@ function App() {
               <AdminProcurementPreview />
           </AdminRoute>
         }
+      />
+      <Route
+          path="/admin-procurement-bids/:id"
+          element={
+          <AdminRoute>
+              <BidLogs/>
+          </AdminRoute>}
       />
       <Route
         path="/create-user"

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -48,11 +48,11 @@ const Navbar = () => {
               onClick={() => navigate("/admin-procurement-requests")}>
               Procurement Requests
             </BasicButton>
+            <BasicButton onClick={() => navigate("/admin")}>
+              Users
+            </BasicButton>
             <BasicButton onClick={() => navigate("/profile")}>
               Profile
-            </BasicButton>
-            <BasicButton onClick={() => navigate("/admin")}>
-              Dashboard
             </BasicButton>
             <BasicButton onClick={onClickLogout}>Logout</BasicButton>
           </Box>

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -44,6 +44,10 @@ const Navbar = () => {
         )}
         {loggedIn && adminUser && (
           <Box sx={{ display: "flex", justifyContent: "end", gap: 2 }}>
+            <BasicButton
+              onClick={() => navigate("/admin-procurement-requests")}>
+              Procurement Requests
+            </BasicButton>
             <BasicButton onClick={() => navigate("/profile")}>
               Profile
             </BasicButton>

--- a/src/pages/AdminProcurementPreview.jsx
+++ b/src/pages/AdminProcurementPreview.jsx
@@ -2,27 +2,37 @@ import React, { use, useEffect, useState } from 'react';
 import {useNavigate, useParams} from "react-router-dom";
 import Layout from "../components/Layout/Layout.jsx";
 import {Box, Card, CardContent, Chip, Container, Typography, Button} from "@mui/material";
-// import PrimaryButton from "../components/Button/PrimaryButton.jsx";
-// import EditIcon from "@mui/icons-material/Edit";
-// import SendIcon from "@mui/icons-material/Send";
-// import CloseIcon from "@mui/icons-material/Close";
-// import StarIcon from "@mui/icons-material/Star";
 import SecondaryButton from "../components/Button/SecondaryButton.jsx";
 import {isAuthenticated, isAdmin} from "../utils/auth.jsx";
 import axios from "axios";
 import {useTheme} from "@mui/material/styles";
-import OutlinedButton from "../components/Button/OutlinedButton.jsx";
 import PrimaryButton from "../components/Button/PrimaryButton.jsx";
 
 
 const AdminProcurementPreview = () => {
     const navigate = useNavigate();
-    const theme = useTheme();
-
     const token = localStorage.getItem("token");
     const [data, setData] = useState(null);
     const { id } = useParams();
-    //const data = dummyData; // fetch this by ID.
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 2;  // Number of bids per page
+    const [view, setView] = useState('bids'); // 'bids' or 'logs'
+
+    // Mock data for bids and logs
+    const mockBids = [
+        { seller: "Seller 1", price: "1000 BAM", timeline: "30 days", proposalText: "Proposal for procurement request 1", submittedAt: "2025-04-10 12:30" },
+        { seller: "Seller 2", price: "1200 BAM", timeline: "25 days", proposalText: "Proposal for procurement request 2", submittedAt: "2025-04-12 14:15" },
+        { seller: "Seller 3", price: "950 BAM", timeline: "35 days", proposalText: "Proposal for procurement request 3", submittedAt: "2025-04-14 10:00" },
+        { seller: "Seller 4", price: "1100 BAM", timeline: "28 days", proposalText: "Proposal for procurement request 4", submittedAt: "2025-04-15 08:00" },
+        { seller: "Seller 5", price: "1050 BAM", timeline: "32 days", proposalText: "Proposal for procurement request 5", submittedAt: "2025-04-17 13:00" },
+        { seller: "Seller 6", price: "980 BAM", timeline: "40 days", proposalText: "Proposal for procurement request 6", submittedAt: "2025-04-20 09:30" }
+    ];
+    const mockLogs = [
+        { action: "Created", time: "2025-04-10 12:30", user: "Admin" },
+        { action: "Edited", time: "2025-04-12 14:15", user: "Admin" },
+        { action: "Created", time: "2025-04-10 12:30", user: "Seller1" },
+        { action: "Edited", time: "2025-04-12 14:15", user: "Seller2" }
+    ];
 
     useEffect(() => {
         if (!isAdmin()) {
@@ -49,26 +59,8 @@ const AdminProcurementPreview = () => {
 
     const handleClose = () => {
         console.log('Close preview');
-        navigate('/admin-procurement-requests')
+        navigate('/admin-procurement-requests');
     };
-
-    {/* Manage bids - mock data for now*/}
-    const [currentPage, setCurrentPage] = useState(1);
-    const itemsPerPage = 2;  // Number of bids per page
-
-    const mockBids = [
-        { seller: "Seller 1", price: "1000 BAM", timeline: "30 days", proposalText: "Proposal for procurement request 1", submittedAt: "2025-04-10 12:30" },
-        { seller: "Seller 2", price: "1200 BAM", timeline: "25 days", proposalText: "Proposal for procurement request 2", submittedAt: "2025-04-12 14:15" },
-        { seller: "Seller 3", price: "950 BAM", timeline: "35 days", proposalText: "Proposal for procurement request 3", submittedAt: "2025-04-14 10:00" },
-        { seller: "Seller 4", price: "1100 BAM", timeline: "28 days", proposalText: "Proposal for procurement request 4", submittedAt: "2025-04-15 08:00" },
-        { seller: "Seller 5", price: "1050 BAM", timeline: "32 days", proposalText: "Proposal for procurement request 5", submittedAt: "2025-04-17 13:00" },
-        { seller: "Seller 6", price: "980 BAM", timeline: "40 days", proposalText: "Proposal for procurement request 6", submittedAt: "2025-04-20 09:30" }
-    ];
-
-    const mockLogs = [
-        { action: "Created", time: "2025-04-10 12:30", user: "Admin" },
-        { action: "Edited", time: "2025-04-12 14:15", user: "Admin" }
-    ];
 
     const indexOfLastBid = currentPage * itemsPerPage;
     const indexOfFirstBid = indexOfLastBid - itemsPerPage;
@@ -86,13 +78,9 @@ const AdminProcurementPreview = () => {
         }
     };
 
-    // Manage view toggling between bids and logs
-    const [view, setView] = useState('bids'); // 'bids' or 'logs'
-
     const toggleView = (newView) => {
         setView(newView);
     };
-    //---------------------------------------------------------------------
 
     if (!data) {
         return (
@@ -102,123 +90,94 @@ const AdminProcurementPreview = () => {
                 </Container>
             </Layout>
         );
-    }else{
+    } else {
         return (
             <Layout>
                 <Container maxWidth="md">
-                    {/* Request details - preview of the request and additional buttons*/}
-                    <Container maxWidth="md">
-                        <Box sx={{mt: 4, position: "relative"}}>
-                            {/* Status and Awarded-to Box Grouped */}
-                            <Box sx={{
-                                position: "absolute",
-                                top: 5,
-                                right: 5,
-                                display: "flex",
-                                flexDirection: "column",
-                                alignItems: "flex-end",
-                            }}>
-                                {/* Status Chip */}
-                                <Chip
-                                    label={data.status.toUpperCase()}
-                                    color={data.status === "draft" ? "warning" : "success"}
-                                    sx={{mb: 1}}
-                                />
-
-
-                                {/* Show "Awarded To" if status is "awarded" */}
-                                {data.status === "awarded" && (
-                                    <Box>
-                                        <Typography variant="body1" color="primary">
-                                            <strong>Awarded to: </strong> Jane Doe
-                                        </Typography>
-                                    </Box>
-                                )}
-                            </Box>
-
-                            <Card>
-                                <CardContent>
-                                    <Typography variant="h3" gutterBottom>
-                                        {data.title}
+                    <Box sx={{ mt: 4, position: "relative" }}>
+                        {/* Status and Awarded-to Box Grouped */}
+                        <Box sx={{
+                            position: "absolute",
+                            top: 5,
+                            right: 5,
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "flex-end",
+                        }}>
+                            <Chip
+                                label={data.status.toUpperCase()}
+                                color={data.status === "draft" ? "warning" : "success"}
+                                sx={{ mb: 1 }}
+                            />
+                            {data.status === "awarded" && (
+                                <Box>
+                                    <Typography variant="body1" color="primary">
+                                        <strong>Awarded to: </strong> Jane Doe
                                     </Typography>
-
-                                    <Typography variant="body1" gutterBottom>
-                                        <strong>Description:</strong> {data.description}
-                                    </Typography>
-                                    <Typography sx={{mb: 1}}>
-                                        <strong>Location:</strong> {data.location}
-                                    </Typography>
-                                    <Typography sx={{mb: 1}}>
-                                        <strong>Deadline:</strong> {data.deadline}
-                                    </Typography>
-                                    <Typography sx={{mb: 1}}>
-                                        <strong>Budget Range:</strong> {data.budget_min} - {data.budget_max} BAM
-                                    </Typography>
-                                    <Typography sx={{mb: 1}}>
-                                        <strong>Category:</strong> {data.procurementCategory.name}
-                                    </Typography>
-
-                                    <Box sx={{mt: 3}}>
-                                        <Typography variant="h5" fontWeight={"bolder"}>Items</Typography>
-                                        {data.items.map((item, index) => (
-                                            <Box key={index} sx={{
-                                                mb: 2,
-                                                p: 2,
-                                                border: '1px solid #ccc',
-                                                borderRadius: 2,
-                                                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
-                                            }}>
-                                                <Typography variant="subtitle1" sx={{mb: 1, fontWeight: 'bold'}}>
-                                                    {item.title}
-                                                </Typography>
-                                                <Typography variant="body2" sx={{mb: 1}}>
-                                                    {item.description}
-                                                </Typography>
-                                                <Typography variant="body2">
-                                                    <strong>Quantity: </strong> {item.quantity}
-                                                </Typography>
-                                            </Box>
-                                        ))}
-                                    </Box>
-
-                                    <Box sx={{mt: 3}}>
-                                        <Typography variant="h5" fontWeight={"bolder"}>Requirements</Typography>
-                                        {data.requirements.map((req, index) => (
-                                            <Box key={index} sx={{
-                                                mb: 2,
-                                                p: 2,
-                                                border: '1px solid #ccc',
-                                                borderRadius: 2,
-                                                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
-                                            }}>
-                                                <Typography variant="subtitle1" sx={{mb: 1}}>
-                                                    Requirement type: <strong>{req.type}</strong>
-                                                </Typography>
-                                                <Typography variant="body2" sx={{mb: 1}}>
-                                                    {req.description}
-                                                </Typography>
-                                            </Box>
-                                        ))}
-                                    </Box>
-                                </CardContent>
-                            </Card>
+                                </Box>
+                            )}
                         </Box>
-                    </Container>
 
-                    {/* List of bids related to the request*/}
+                        <Card>
+                            <CardContent>
+                                <Typography variant="h3" gutterBottom>{data.title}</Typography>
+                                <Typography variant="body1" gutterBottom><strong>Description:</strong> {data.description}</Typography>
+                                <Typography sx={{ mb: 1 }}><strong>Location:</strong> {data.location}</Typography>
+                                <Typography sx={{ mb: 1 }}><strong>Deadline:</strong> {data.deadline}</Typography>
+                                <Typography sx={{ mb: 1 }}><strong>Budget Range:</strong> {data.budget_min} - {data.budget_max} BAM</Typography>
+                                <Typography sx={{ mb: 1 }}><strong>Category:</strong> {data.procurementCategory.name}</Typography>
+
+                                <Box sx={{ mt: 3 }}>
+                                    <Typography variant="h5" fontWeight={"bolder"}>Items</Typography>
+                                    {data.items.map((item, index) => (
+                                        <Box key={index} sx={{
+                                            mb: 2,
+                                            p: 2,
+                                            border: '1px solid #ccc',
+                                            borderRadius: 2,
+                                            boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+                                        }}>
+                                            <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'bold' }}>
+                                                {item.title}
+                                            </Typography>
+                                            <Typography variant="body2" sx={{ mb: 1 }}>{item.description}</Typography>
+                                            <Typography variant="body2"><strong>Quantity: </strong> {item.quantity}</Typography>
+                                        </Box>
+                                    ))}
+                                </Box>
+
+                                <Box sx={{ mt: 3 }}>
+                                    <Typography variant="h5" fontWeight={"bolder"}>Requirements</Typography>
+                                    {data.requirements.map((req, index) => (
+                                        <Box key={index} sx={{
+                                            mb: 2,
+                                            p: 2,
+                                            border: '1px solid #ccc',
+                                            borderRadius: 2,
+                                            boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+                                        }}>
+                                            <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                                                Requirement type: <strong>{req.type}</strong>
+                                            </Typography>
+                                            <Typography variant="body2" sx={{ mb: 1 }}>{req.description}</Typography>
+                                        </Box>
+                                    ))}
+                                </Box>
+                            </CardContent>
+                        </Card>
+                    </Box>
 
                     <Container maxWidth="md">
-                        <Card sx={{ mt: 3}}>
+                        <Card sx={{ mt: 3 }}>
                             <CardContent>
-                                {/* Toggle between bids and logs */}
-                                <Box sx={{display: 'flex', mb: 2}}>
-                                    <PrimaryButton onClick={() => toggleView('bids')} sx={{ marginRight: 2, textTransform: 'none'}} variant={view === 'bids' ? 'contained' : 'outlined'}>Bids</PrimaryButton>
+                                <Box sx={{ display: 'flex', mb: 2 }}>
+                                    <PrimaryButton onClick={() => toggleView('bids')} sx={{ marginRight: 2, textTransform: 'none' }} variant={view === 'bids' ? 'contained' : 'outlined'}>Bids</PrimaryButton>
                                     <PrimaryButton onClick={() => toggleView('logs')} variant={view === 'logs' ? 'contained' : 'outlined'}>Logs</PrimaryButton>
                                 </Box>
 
                                 {view === 'bids' && (
                                     <>
-                                        {mockBids.map((bid, index) => (
+                                        {currentBids.map((bid, index) => (
                                             <Box key={index} sx={{
                                                 mb: 2,
                                                 p: 2,
@@ -227,51 +186,41 @@ const AdminProcurementPreview = () => {
                                                 boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
                                             }}>
                                                 <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'bold' }}>Seller: {bid.seller}</Typography>
-                                                <Typography variant="body2" sx={{ mb: 1 }}>
-                                                    <strong>Price:</strong> {bid.price}
-                                                </Typography>
-                                                <Typography variant="body2" sx={{ mb: 1 }}>
-                                                    <strong>Timeline:</strong> {bid.timeline}
-                                                </Typography>
-                                                <Typography variant="body2" sx={{ mb: 1 }}>
-                                                    <strong>Proposal:</strong> {bid.proposalText}
-                                                </Typography>
-                                                <Typography variant="body2" sx={{ mb: 1 }}>
-                                                    <strong>Submitted at:</strong> {bid.submittedAt}
-                                                </Typography>
+                                                <Typography variant="body2" sx={{ mb: 1 }}><strong>Price:</strong> {bid.price}</Typography>
+                                                <Typography variant="body2" sx={{ mb: 1 }}><strong>Timeline:</strong> {bid.timeline}</Typography>
+                                                <Typography variant="body2" sx={{ mb: 1 }}><strong>Proposal:</strong> {bid.proposalText}</Typography>
+                                                <Typography variant="body2" sx={{ mb: 1 }}><strong>Submitted At:</strong> {bid.submittedAt}</Typography>
                                             </Box>
                                         ))}
+
+                                        {/* Pagination Controls */}
+                                        {view === 'bids' && (
+                                            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                                                <PrimaryButton onClick={handlePreviousPage} disabled={currentPage === 1} sx={{ marginRight: 2, textTransform: 'none'}}>Previous</PrimaryButton>
+                                                <PrimaryButton onClick={handleNextPage} disabled={currentPage === Math.ceil(mockBids.length / itemsPerPage)}>Next</PrimaryButton>
+                                            </Box>
+                                        )}
                                     </>
                                 )}
 
                                 {view === 'logs' && (
-                                    <>
+                                    <Box>
                                         {mockLogs.map((log, index) => (
                                             <Box key={index} sx={{
-                                                mb: 2,
-                                                p: 2,
-                                                border: '1px solid #ccc',
-                                                borderRadius: 2,
-                                                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+                                                mb: 1, p: 1, border: '1px solid #ccc',
                                             }}>
-                                                <Typography variant="subtitle1" sx={{ mb: 1 }}>
-                                                    <strong>Action:</strong> {log.action}
-                                                </Typography>
-                                                <Typography variant="body2" sx={{ mb: 1 }}>
-                                                    <strong>Time:</strong> {log.time}
-                                                </Typography>
-                                                <Typography variant="body2" sx={{ mb: 1 }}>
-                                                    <strong>User:</strong> {log.user}
-                                                </Typography>
+                                                <Typography variant="body2"><strong>Action:</strong> {log.action}</Typography>
+                                                <Typography variant="body2"><strong>Time:</strong> {log.time}</Typography>
+                                                <Typography variant="body2"><strong>User:</strong> {log.user}</Typography>
                                             </Box>
                                         ))}
-                                    </>
+                                    </Box>
                                 )}
                             </CardContent>
                         </Card>
-
                     </Container>
-                    <Box sx={{ mt: 4, display: 'flex', justifyContent: 'center' }}>
+
+                    <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
                         <SecondaryButton onClick={handleClose}>
                             Close Preview
                         </SecondaryButton>

--- a/src/pages/AdminProcurementPreview.jsx
+++ b/src/pages/AdminProcurementPreview.jsx
@@ -1,7 +1,7 @@
 import React, { use, useEffect, useState } from 'react';
 import {useNavigate, useParams} from "react-router-dom";
 import Layout from "../components/Layout/Layout.jsx";
-import {Box, Card, CardContent, Chip, Container, Typography} from "@mui/material";
+import {Box, Card, CardContent, Chip, Container, Typography, Button} from "@mui/material";
 // import PrimaryButton from "../components/Button/PrimaryButton.jsx";
 // import EditIcon from "@mui/icons-material/Edit";
 // import SendIcon from "@mui/icons-material/Send";
@@ -11,29 +11,9 @@ import SecondaryButton from "../components/Button/SecondaryButton.jsx";
 import {isAuthenticated, isAdmin} from "../utils/auth.jsx";
 import axios from "axios";
 import {useTheme} from "@mui/material/styles";
+import OutlinedButton from "../components/Button/OutlinedButton.jsx";
+import PrimaryButton from "../components/Button/PrimaryButton.jsx";
 
-/* Dummy data jer nije implemented api*/
-const dummyData = {
-    id: 1,
-    title: "Procurement of Office Chairs",
-    description: "Need ergonomic chairs for all offices",
-    location: "Sarajevo",
-    deadline: "2025-05-01",
-    budget_min: 500,
-    budget_max: 1500,
-    status: "draft",
-    procurementCategory: {
-        name: "Office Equipment"
-    },
-    items: [
-        { title: "Chair Model A", description: "Mesh back, adjustable height", quantity: 20 },
-        { title: "Chair Model B", description: "Leather, fixed arms", quantity: 10 }
-    ],
-    requirements: [
-        { type: "Delivery", description: "Within 10 days after contract signing" },
-        { type: "Warranty", description: "Minimum 2 years" }
-    ]
-};
 
 const AdminProcurementPreview = () => {
     const navigate = useNavigate();
@@ -72,6 +52,36 @@ const AdminProcurementPreview = () => {
         navigate('/admin-procurement-requests')
     };
 
+    {/* Manage bids - mock data for now*/}
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 2;  // Number of bids per page
+
+    const mockBids = [
+        { seller: "Seller 1", price: "1000 BAM", timeline: "30 days", proposalText: "Proposal for procurement request 1", submittedAt: "2025-04-10 12:30" },
+        { seller: "Seller 2", price: "1200 BAM", timeline: "25 days", proposalText: "Proposal for procurement request 2", submittedAt: "2025-04-12 14:15" },
+        { seller: "Seller 3", price: "950 BAM", timeline: "35 days", proposalText: "Proposal for procurement request 3", submittedAt: "2025-04-14 10:00" },
+        { seller: "Seller 4", price: "1100 BAM", timeline: "28 days", proposalText: "Proposal for procurement request 4", submittedAt: "2025-04-15 08:00" },
+        { seller: "Seller 5", price: "1050 BAM", timeline: "32 days", proposalText: "Proposal for procurement request 5", submittedAt: "2025-04-17 13:00" },
+        { seller: "Seller 6", price: "980 BAM", timeline: "40 days", proposalText: "Proposal for procurement request 6", submittedAt: "2025-04-20 09:30" }
+    ];
+
+    const indexOfLastBid = currentPage * itemsPerPage;
+    const indexOfFirstBid = indexOfLastBid - itemsPerPage;
+    const currentBids = mockBids.slice(indexOfFirstBid, indexOfLastBid);
+
+    const handleNextPage = () => {
+        if (currentPage < Math.ceil(mockBids.length / itemsPerPage)) {
+            setCurrentPage(prev => prev + 1);
+        }
+    };
+
+    const handlePreviousPage = () => {
+        if (currentPage > 1) {
+            setCurrentPage(prev => prev - 1);
+        }
+    };
+    //---------------------------------------------------------------------
+
     if (!data) {
         return (
             <Layout>
@@ -83,9 +93,9 @@ const AdminProcurementPreview = () => {
     }else{
         return (
             <Layout>
-                <Container maxWidth="sm">
+                <Container maxWidth="md">
                     {/* Request details - preview of the request and additional buttons*/}
-                    <Container maxWidth="sm">
+                    <Container maxWidth="md">
                         <Box sx={{mt: 4, position: "relative"}}>
                             {/* Status and Awarded-to Box Grouped */}
                             <Box sx={{
@@ -183,10 +193,36 @@ const AdminProcurementPreview = () => {
                         </Box>
                     </Container>
                     {/* List of bids related to the request*/}
-                    <Container maxWidth="sm"></Container>
-                    <SecondaryButton onClick={handleClose}>
-                        Close Preview
-                    </SecondaryButton>
+                    <Container maxWidth="md">
+                        <Box sx={{mt: 4, position: "relative"}}>
+                            <Typography variant="h5" fontWeight={"bolder"}>Bids</Typography>
+                            {currentBids.map((bid, index) => (
+                                <Box key={index} sx={{
+                                    mb: 2,
+                                    p: 2,
+                                    border: '1px solid #ccc',
+                                    borderRadius: 2,
+                                    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+                                }}>
+                                    <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'bold' }}>Seller: {bid.seller}</Typography>
+                                    <Typography variant="body2" sx={{ mb: 1 }}>Price: {bid.price}</Typography>
+                                    <Typography variant="body2" sx={{ mb: 1 }}>Timeline: {bid.timeline}</Typography>
+                                    <Typography variant="body2" sx={{ mb: 1 }}>Proposal: {bid.proposalText}</Typography>
+                                    <Typography variant="body2" sx={{ mb: 1 }}>Submitted at: {bid.submittedAt}</Typography>
+                                </Box>
+                            ))}
+                            {/* Pagination controls */}
+                            <Box sx={{ mt: 2, display: "flex", justifyContent: "space-between" }}>
+                                <PrimaryButton variant="outlined" onClick={handlePreviousPage} disabled={currentPage === 1}>Previous</PrimaryButton>
+                                <OutlinedButton variant="outlined" onClick={handleNextPage} disabled={currentPage === Math.ceil(mockBids.length / itemsPerPage)}>Next</OutlinedButton>
+                            </Box>
+                        </Box>
+                    </Container>
+                    <Box sx={{ mt: 4, display: 'flex', justifyContent: 'center' }}>
+                        <SecondaryButton onClick={handleClose}>
+                            Close Preview
+                        </SecondaryButton>
+                    </Box>
                 </Container>
             </Layout>
         );

--- a/src/pages/AdminProcurementPreview.jsx
+++ b/src/pages/AdminProcurementPreview.jsx
@@ -214,6 +214,14 @@ const AdminProcurementPreview = () => {
                                     }}
                                     onClick={() => navigate(`/admin-procurement-requests/${id}/bid/${index + 1}`)} // Kad se klikne na red
                                 >
+                                    <Box sx={{ position: 'relative', mb: 2 }}>
+                                        <Chip
+                                            label={`Score: ${bid.score !== null ? bid.score : 'N/A'}`}
+                                            color="primary"
+                                            size="medium"
+                                            sx={{ position: 'absolute', top: 0, right: 0 }}
+                                        />
+                                    </Box>
                                     <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1 }}>
                                         Seller: {bid.seller}
                                     </Typography>

--- a/src/pages/AdminProcurementPreview.jsx
+++ b/src/pages/AdminProcurementPreview.jsx
@@ -170,7 +170,7 @@ const AdminProcurementPreview = () => {
                                         borderRadius: 2,
                                         boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
                                     }}
-                                    onClick={() => navigate(`/admin-procurement-bids/${bid.id}`)} // Kad se klikne na red
+                                    onClick={() => navigate(`/admin-procurement-requests/${id}/bid/${bid.id}`)} // Kad se klikne na red
                                 >
                                     <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1 }}>
                                         Seller: {bid.seller}

--- a/src/pages/AdminProcurementPreview.jsx
+++ b/src/pages/AdminProcurementPreview.jsx
@@ -17,33 +17,6 @@ const AdminProcurementPreview = () => {
     const [currentPage, setCurrentPage] = useState(1);
     const itemsPerPage = 2;  // Number of bids per page
 
-    //mock kriterji dok ne skontam gdje je ruta koja ih vraca :)
-    const kriterijiMock = {
-        evaluationCriteria: [
-            {
-                criteriaType: {
-                    name: "Price"
-                },
-                weight: 50,
-                is_must_have: true
-            },
-            {
-                criteriaType: {
-                    name: "Delivery Time"
-                },
-                weight: 30,
-                is_must_have: false
-            },
-            {
-                criteriaType: {
-                    name: "Warranty"
-                },
-                weight: 20,
-                is_must_have: false
-            }
-        ]
-    };
-
     useEffect(() => {
         if (!isAdmin()) {
             if (!isAuthenticated()) {
@@ -86,6 +59,16 @@ const AdminProcurementPreview = () => {
     const handleClose = () => {
         console.log('Close preview');
         navigate('/admin-procurement-requests');
+    };
+
+    const formatDate = (dateString) => {
+        const date = new Date(dateString);
+        const yyyy = date.getFullYear();
+        const mm = String(date.getMonth() + 1).padStart(2, '0');
+        const dd = String(date.getDate()).padStart(2, '0');
+        const hh = String(date.getHours()).padStart(2, '0');
+        const min =String(date.getMinutes()).padStart(2, '0');
+        return `${yyyy}-${mm}-${dd} at ${hh}:${min}`;
     };
 
     const indexOfLastBid = currentPage * itemsPerPage;
@@ -145,10 +128,12 @@ const AdminProcurementPreview = () => {
                                 <Typography variant="h3" gutterBottom>{data.title}</Typography>
                                 <Typography variant="body1" gutterBottom><strong>Description:</strong> {data.description}</Typography>
                                 <Typography sx={{ mb: 1 }}><strong>Location:</strong> {data.location}</Typography>
-                                <Typography sx={{ mb: 1 }}><strong>Deadline:</strong> {data.deadline}</Typography>
+                                <Typography sx={{ mb: 1 }}><strong>Deadline:</strong> {data.deadline? `${formatDate(data.deadline)}` : "No deadline"}</Typography>
                                 <Typography sx={{ mb: 1 }}><strong>Budget Range:</strong> {data.budget_min} - {data.budget_max} BAM</Typography>
                                 <Typography sx={{ mb: 1 }}><strong>Category:</strong> {data.procurementCategory.name}</Typography>
-
+                                <Typography sx={{ mb: 1 }}>
+                                    <strong>Enable bid proposals editing : </strong> {data.bid_edit_deadline? `Yes, until ${formatDate(data.bid_edit_deadline)}` : "No"}
+                                </Typography>
                                 <Box sx={{ mt: 3 }}>
                                     <Typography variant="h5" fontWeight={"bolder"}>Items</Typography>
                                     {data.items.map((item, index) => (
@@ -185,10 +170,11 @@ const AdminProcurementPreview = () => {
                                         </Box>
                                     ))}
                                 </Box>
-                                {kriterijiMock.evaluationCriteria.length > 0 && (
+                                {/* Ovo je dio koji se odnosi na kriteriji, radi kada ima controller na be */}
+                                {data.evaluationCriteria.length > 0 && (
                                 <Box sx={{ mt: 3}}>
                                     <Typography variant="h5" fontWeight={"bolder"}>Criteria</Typography>
-                                    {kriterijiMock.evaluationCriteria.map((crit, index) => (
+                                    {data.evaluationCriteria.map((crit, index) => (
                                         <Box key={index} sx={{
                                             mb: 2,
                                             p: 2,
@@ -241,7 +227,7 @@ const AdminProcurementPreview = () => {
                                         <strong>Proposal:</strong> {bid.proposalText}
                                     </Typography>
                                     <Typography variant="body2">
-                                        <strong>Submitted At:</strong> {bid.submitted_at}
+                                        <strong>Submitted At:</strong> {bid.submitted_at? `${formatDate(bid.submitted_at)}` : "Unknown"}
                                     </Typography>
                                 </Box>
                             ))}

--- a/src/pages/AdminProcurementPreview.jsx
+++ b/src/pages/AdminProcurementPreview.jsx
@@ -1,0 +1,196 @@
+import React, { use, useEffect, useState } from 'react';
+import {useNavigate, useParams} from "react-router-dom";
+import Layout from "../components/Layout/Layout.jsx";
+import {Box, Card, CardContent, Chip, Container, Typography} from "@mui/material";
+// import PrimaryButton from "../components/Button/PrimaryButton.jsx";
+// import EditIcon from "@mui/icons-material/Edit";
+// import SendIcon from "@mui/icons-material/Send";
+// import CloseIcon from "@mui/icons-material/Close";
+// import StarIcon from "@mui/icons-material/Star";
+import SecondaryButton from "../components/Button/SecondaryButton.jsx";
+import {isAuthenticated, isAdmin} from "../utils/auth.jsx";
+import axios from "axios";
+import {useTheme} from "@mui/material/styles";
+
+/* Dummy data jer nije implemented api*/
+const dummyData = {
+    id: 1,
+    title: "Procurement of Office Chairs",
+    description: "Need ergonomic chairs for all offices",
+    location: "Sarajevo",
+    deadline: "2025-05-01",
+    budget_min: 500,
+    budget_max: 1500,
+    status: "draft",
+    procurementCategory: {
+        name: "Office Equipment"
+    },
+    items: [
+        { title: "Chair Model A", description: "Mesh back, adjustable height", quantity: 20 },
+        { title: "Chair Model B", description: "Leather, fixed arms", quantity: 10 }
+    ],
+    requirements: [
+        { type: "Delivery", description: "Within 10 days after contract signing" },
+        { type: "Warranty", description: "Minimum 2 years" }
+    ]
+};
+
+const AdminProcurementPreview = () => {
+    const navigate = useNavigate();
+    const theme = useTheme();
+
+    const token = localStorage.getItem("token");
+    const [data, setData] = useState(null);
+    const { id } = useParams();
+    //const data = dummyData; // fetch this by ID.
+
+    useEffect(() => {
+        if (!isAdmin()) {
+            if (!isAuthenticated()) {
+                window.location.href = "/login";
+            } else {
+                window.location.href = "/";
+            }
+            return;
+        }
+
+        axios.get(`${import.meta.env.VITE_API_URL}/api/procurement-request/${id}`, {
+            headers: { Authorization: `Bearer ${token}` },
+        })
+            .then((response) => {
+                setData(response.data);
+                console.log("Fetched request data:", response.data);
+            })
+            .catch((error) => {
+                console.error(`Error fetching request with id=${id}:`, error);
+            });
+
+    }, [token, id]);
+
+    const handleClose = () => {
+        console.log('Close preview');
+        navigate('/admin-procurement-requests')
+    };
+
+    if (!data) {
+        return (
+            <Layout>
+                <Container maxWidth="md">
+                    <Typography variant="h6" sx={{ mt: 4 }}>Loading procurement request...</Typography>
+                </Container>
+            </Layout>
+        );
+    }else{
+        return (
+            <Layout>
+                <Container maxWidth="sm">
+                    {/* Request details - preview of the request and additional buttons*/}
+                    <Container maxWidth="sm">
+                        <Box sx={{mt: 4, position: "relative"}}>
+                            {/* Status and Awarded-to Box Grouped */}
+                            <Box sx={{
+                                position: "absolute",
+                                top: 5,
+                                right: 5,
+                                display: "flex",
+                                flexDirection: "column",
+                                alignItems: "flex-end",
+                            }}>
+                                {/* Status Chip */}
+                                <Chip
+                                    label={data.status.toUpperCase()}
+                                    color={data.status === "draft" ? "warning" : "success"}
+                                    sx={{mb: 1}}
+                                />
+
+
+                                {/* Show "Awarded To" if status is "awarded" */}
+                                {data.status === "awarded" && (
+                                    <Box>
+                                        <Typography variant="body1" color="primary">
+                                            <strong>Awarded to: </strong> Jane Doe
+                                        </Typography>
+                                    </Box>
+                                )}
+                            </Box>
+
+                            <Card>
+                                <CardContent>
+                                    <Typography variant="h3" gutterBottom>
+                                        {data.title}
+                                    </Typography>
+
+                                    <Typography variant="body1" gutterBottom>
+                                        <strong>Description:</strong> {data.description}
+                                    </Typography>
+                                    <Typography sx={{mb: 1}}>
+                                        <strong>Location:</strong> {data.location}
+                                    </Typography>
+                                    <Typography sx={{mb: 1}}>
+                                        <strong>Deadline:</strong> {data.deadline}
+                                    </Typography>
+                                    <Typography sx={{mb: 1}}>
+                                        <strong>Budget Range:</strong> {data.budget_min} - {data.budget_max} BAM
+                                    </Typography>
+                                    <Typography sx={{mb: 1}}>
+                                        <strong>Category:</strong> {data.procurementCategory.name}
+                                    </Typography>
+
+                                    <Box sx={{mt: 3}}>
+                                        <Typography variant="h5" fontWeight={"bolder"}>Items</Typography>
+                                        {data.items.map((item, index) => (
+                                            <Box key={index} sx={{
+                                                mb: 2,
+                                                p: 2,
+                                                border: '1px solid #ccc',
+                                                borderRadius: 2,
+                                                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+                                            }}>
+                                                <Typography variant="subtitle1" sx={{mb: 1, fontWeight: 'bold'}}>
+                                                    {item.title}
+                                                </Typography>
+                                                <Typography variant="body2" sx={{mb: 1}}>
+                                                    {item.description}
+                                                </Typography>
+                                                <Typography variant="body2">
+                                                    <strong>Quantity: </strong> {item.quantity}
+                                                </Typography>
+                                            </Box>
+                                        ))}
+                                    </Box>
+
+                                    <Box sx={{mt: 3}}>
+                                        <Typography variant="h5" fontWeight={"bolder"}>Requirements</Typography>
+                                        {data.requirements.map((req, index) => (
+                                            <Box key={index} sx={{
+                                                mb: 2,
+                                                p: 2,
+                                                border: '1px solid #ccc',
+                                                borderRadius: 2,
+                                                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+                                            }}>
+                                                <Typography variant="subtitle1" sx={{mb: 1}}>
+                                                    Requirement type: <strong>{req.type}</strong>
+                                                </Typography>
+                                                <Typography variant="body2" sx={{mb: 1}}>
+                                                    {req.description}
+                                                </Typography>
+                                            </Box>
+                                        ))}
+                                    </Box>
+                                </CardContent>
+                            </Card>
+                        </Box>
+                    </Container>
+                    {/* List of bids related to the request*/}
+                    <Container maxWidth="sm"></Container>
+                    <SecondaryButton onClick={handleClose}>
+                        Close Preview
+                    </SecondaryButton>
+                </Container>
+            </Layout>
+        );
+    }
+};
+
+export default AdminProcurementPreview;

--- a/src/pages/AdminProcurementPreview.jsx
+++ b/src/pages/AdminProcurementPreview.jsx
@@ -17,6 +17,33 @@ const AdminProcurementPreview = () => {
     const [currentPage, setCurrentPage] = useState(1);
     const itemsPerPage = 2;  // Number of bids per page
 
+    //mock kriterji dok ne skontam gdje je ruta koja ih vraca :)
+    const kriterijiMock = {
+        evaluationCriteria: [
+            {
+                criteriaType: {
+                    name: "Price"
+                },
+                weight: 50,
+                is_must_have: true
+            },
+            {
+                criteriaType: {
+                    name: "Delivery Time"
+                },
+                weight: 30,
+                is_must_have: false
+            },
+            {
+                criteriaType: {
+                    name: "Warranty"
+                },
+                weight: 20,
+                is_must_have: false
+            }
+        ]
+    };
+
     useEffect(() => {
         if (!isAdmin()) {
             if (!isAuthenticated()) {
@@ -158,6 +185,29 @@ const AdminProcurementPreview = () => {
                                         </Box>
                                     ))}
                                 </Box>
+                                {kriterijiMock.evaluationCriteria.length > 0 && (
+                                <Box sx={{ mt: 3}}>
+                                    <Typography variant="h5" fontWeight={"bolder"}>Criteria</Typography>
+                                    {kriterijiMock.evaluationCriteria.map((crit, index) => (
+                                        <Box key={index} sx={{
+                                            mb: 2,
+                                            p: 2,
+                                            border: '1px solid #ccc',
+                                            borderRadius: 2,
+                                            boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+                                        }}>
+                                            <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'bold' }}>
+                                                {crit.criteriaType.name}
+                                            </Typography>
+                                            <Typography variant="body2" sx={{ mb: 1 }}>
+                                                Weight: <strong> {crit.weight}% </strong>
+                                            </Typography>
+                                            <Typography variant="body2">
+                                                Is must have: <strong> {crit.is_must_have ? "Yes" : "No"}  </strong>
+                                            </Typography>
+                                        </Box>
+                                    ))}
+                                </Box>)}
                             </CardContent>
                         </Card>
                     </Box>

--- a/src/pages/AdminProcurementPreview.jsx
+++ b/src/pages/AdminProcurementPreview.jsx
@@ -65,6 +65,11 @@ const AdminProcurementPreview = () => {
         { seller: "Seller 6", price: "980 BAM", timeline: "40 days", proposalText: "Proposal for procurement request 6", submittedAt: "2025-04-20 09:30" }
     ];
 
+    const mockLogs = [
+        { action: "Created", time: "2025-04-10 12:30", user: "Admin" },
+        { action: "Edited", time: "2025-04-12 14:15", user: "Admin" }
+    ];
+
     const indexOfLastBid = currentPage * itemsPerPage;
     const indexOfFirstBid = indexOfLastBid - itemsPerPage;
     const currentBids = mockBids.slice(indexOfFirstBid, indexOfLastBid);
@@ -79,6 +84,13 @@ const AdminProcurementPreview = () => {
         if (currentPage > 1) {
             setCurrentPage(prev => prev - 1);
         }
+    };
+
+    // Manage view toggling between bids and logs
+    const [view, setView] = useState('bids'); // 'bids' or 'logs'
+
+    const toggleView = (newView) => {
+        setView(newView);
     };
     //---------------------------------------------------------------------
 
@@ -192,31 +204,72 @@ const AdminProcurementPreview = () => {
                             </Card>
                         </Box>
                     </Container>
+
                     {/* List of bids related to the request*/}
+
                     <Container maxWidth="md">
-                        <Box sx={{mt: 4, position: "relative"}}>
-                            <Typography variant="h5" fontWeight={"bolder"}>Bids</Typography>
-                            {currentBids.map((bid, index) => (
-                                <Box key={index} sx={{
-                                    mb: 2,
-                                    p: 2,
-                                    border: '1px solid #ccc',
-                                    borderRadius: 2,
-                                    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
-                                }}>
-                                    <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'bold' }}>Seller: {bid.seller}</Typography>
-                                    <Typography variant="body2" sx={{ mb: 1 }}>Price: {bid.price}</Typography>
-                                    <Typography variant="body2" sx={{ mb: 1 }}>Timeline: {bid.timeline}</Typography>
-                                    <Typography variant="body2" sx={{ mb: 1 }}>Proposal: {bid.proposalText}</Typography>
-                                    <Typography variant="body2" sx={{ mb: 1 }}>Submitted at: {bid.submittedAt}</Typography>
+                        <Card sx={{ mt: 3}}>
+                            <CardContent>
+                                {/* Toggle between bids and logs */}
+                                <Box sx={{display: 'flex', mb: 2}}>
+                                    <PrimaryButton onClick={() => toggleView('bids')} sx={{ marginRight: 2, textTransform: 'none'}} variant={view === 'bids' ? 'contained' : 'outlined'}>Bids</PrimaryButton>
+                                    <PrimaryButton onClick={() => toggleView('logs')} variant={view === 'logs' ? 'contained' : 'outlined'}>Logs</PrimaryButton>
                                 </Box>
-                            ))}
-                            {/* Pagination controls */}
-                            <Box sx={{ mt: 2, display: "flex", justifyContent: "space-between" }}>
-                                <PrimaryButton variant="outlined" onClick={handlePreviousPage} disabled={currentPage === 1}>Previous</PrimaryButton>
-                                <OutlinedButton variant="outlined" onClick={handleNextPage} disabled={currentPage === Math.ceil(mockBids.length / itemsPerPage)}>Next</OutlinedButton>
-                            </Box>
-                        </Box>
+
+                                {view === 'bids' && (
+                                    <>
+                                        {mockBids.map((bid, index) => (
+                                            <Box key={index} sx={{
+                                                mb: 2,
+                                                p: 2,
+                                                border: '1px solid #ccc',
+                                                borderRadius: 2,
+                                                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+                                            }}>
+                                                <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'bold' }}>Seller: {bid.seller}</Typography>
+                                                <Typography variant="body2" sx={{ mb: 1 }}>
+                                                    <strong>Price:</strong> {bid.price}
+                                                </Typography>
+                                                <Typography variant="body2" sx={{ mb: 1 }}>
+                                                    <strong>Timeline:</strong> {bid.timeline}
+                                                </Typography>
+                                                <Typography variant="body2" sx={{ mb: 1 }}>
+                                                    <strong>Proposal:</strong> {bid.proposalText}
+                                                </Typography>
+                                                <Typography variant="body2" sx={{ mb: 1 }}>
+                                                    <strong>Submitted at:</strong> {bid.submittedAt}
+                                                </Typography>
+                                            </Box>
+                                        ))}
+                                    </>
+                                )}
+
+                                {view === 'logs' && (
+                                    <>
+                                        {mockLogs.map((log, index) => (
+                                            <Box key={index} sx={{
+                                                mb: 2,
+                                                p: 2,
+                                                border: '1px solid #ccc',
+                                                borderRadius: 2,
+                                                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+                                            }}>
+                                                <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                                                    <strong>Action:</strong> {log.action}
+                                                </Typography>
+                                                <Typography variant="body2" sx={{ mb: 1 }}>
+                                                    <strong>Time:</strong> {log.time}
+                                                </Typography>
+                                                <Typography variant="body2" sx={{ mb: 1 }}>
+                                                    <strong>User:</strong> {log.user}
+                                                </Typography>
+                                            </Box>
+                                        ))}
+                                    </>
+                                )}
+                            </CardContent>
+                        </Card>
+
                     </Container>
                     <Box sx={{ mt: 4, display: 'flex', justifyContent: 'center' }}>
                         <SecondaryButton onClick={handleClose}>

--- a/src/pages/AdminProcurementPreview.jsx
+++ b/src/pages/AdminProcurementPreview.jsx
@@ -1,7 +1,7 @@
 import React, { use, useEffect, useState } from 'react';
 import {useNavigate, useParams} from "react-router-dom";
 import Layout from "../components/Layout/Layout.jsx";
-import {Box, Card, CardContent, Chip, Container, Typography, Button} from "@mui/material";
+import {Box, Card, CardContent, Chip, Container, Typography} from "@mui/material";
 import SecondaryButton from "../components/Button/SecondaryButton.jsx";
 import {isAuthenticated, isAdmin} from "../utils/auth.jsx";
 import axios from "axios";
@@ -16,22 +16,15 @@ const AdminProcurementPreview = () => {
     const { id } = useParams();
     const [currentPage, setCurrentPage] = useState(1);
     const itemsPerPage = 2;  // Number of bids per page
-    const [view, setView] = useState('bids'); // 'bids' or 'logs'
 
-    // Mock data for bids and logs
-    const mockBids = [
-        { seller: "Seller 1", price: "1000 BAM", timeline: "30 days", proposalText: "Proposal for procurement request 1", submittedAt: "2025-04-10 12:30" },
-        { seller: "Seller 2", price: "1200 BAM", timeline: "25 days", proposalText: "Proposal for procurement request 2", submittedAt: "2025-04-12 14:15" },
-        { seller: "Seller 3", price: "950 BAM", timeline: "35 days", proposalText: "Proposal for procurement request 3", submittedAt: "2025-04-14 10:00" },
-        { seller: "Seller 4", price: "1100 BAM", timeline: "28 days", proposalText: "Proposal for procurement request 4", submittedAt: "2025-04-15 08:00" },
-        { seller: "Seller 5", price: "1050 BAM", timeline: "32 days", proposalText: "Proposal for procurement request 5", submittedAt: "2025-04-17 13:00" },
-        { seller: "Seller 6", price: "980 BAM", timeline: "40 days", proposalText: "Proposal for procurement request 6", submittedAt: "2025-04-20 09:30" }
-    ];
-    const mockLogs = [
-        { action: "Created", time: "2025-04-10 12:30", user: "Admin" },
-        { action: "Edited", time: "2025-04-12 14:15", user: "Admin" },
-        { action: "Created", time: "2025-04-10 12:30", user: "Seller1" },
-        { action: "Edited", time: "2025-04-12 14:15", user: "Seller2" }
+    // Mock data for bids
+    const bids = [
+        { id: 1, seller: "Seller 1", price: "1000 BAM", timeline: "30 days", proposalText: "Proposal for procurement request 1", submitted_at: "2025-04-10 12:30" },
+        { id: 2,seller: "Seller 2", price: "1200 BAM", timeline: "25 days", proposalText: "Proposal for procurement request 2", submitted_at: "2025-04-12 14:15" },
+        { id: 3,seller: "Seller 3", price: "950 BAM", timeline: "35 days", proposalText: "Proposal for procurement request 3", submitted_at: "2025-04-14 10:00" },
+        { id: 4,seller: "Seller 4", price: "1100 BAM", timeline: "28 days", proposalText: "Proposal for procurement request 4", submitted_at: "2025-04-15 08:00" },
+        { id: 5,seller: "Seller 5", price: "1050 BAM", timeline: "32 days", proposalText: "Proposal for procurement request 5", submitted_at: "2025-04-17 13:00" },
+        { id: 6,seller: "Seller 6", price: "980 BAM", timeline: "40 days", proposalText: "Proposal for procurement request 6", submitted_at: "2025-04-20 09:30" }
     ];
 
     useEffect(() => {
@@ -64,10 +57,10 @@ const AdminProcurementPreview = () => {
 
     const indexOfLastBid = currentPage * itemsPerPage;
     const indexOfFirstBid = indexOfLastBid - itemsPerPage;
-    const currentBids = mockBids.slice(indexOfFirstBid, indexOfLastBid);
+    const currentBids = bids.slice(indexOfFirstBid, indexOfLastBid);
 
     const handleNextPage = () => {
-        if (currentPage < Math.ceil(mockBids.length / itemsPerPage)) {
+        if (currentPage < Math.ceil(bids.length / itemsPerPage)) {
             setCurrentPage(prev => prev + 1);
         }
     };
@@ -76,10 +69,6 @@ const AdminProcurementPreview = () => {
         if (currentPage > 1) {
             setCurrentPage(prev => prev - 1);
         }
-    };
-
-    const toggleView = (newView) => {
-        setView(newView);
     };
 
     if (!data) {
@@ -166,65 +155,64 @@ const AdminProcurementPreview = () => {
                             </CardContent>
                         </Card>
                     </Box>
-
                     <Container maxWidth="md">
-                        <Card sx={{ mt: 3 }}>
-                            <CardContent>
-                                <Box sx={{ display: 'flex', mb: 2 }}>
-                                    <PrimaryButton onClick={() => toggleView('bids')} sx={{ marginRight: 2, textTransform: 'none' }} variant={view === 'bids' ? 'contained' : 'outlined'}>Bids</PrimaryButton>
-                                    <PrimaryButton onClick={() => toggleView('logs')} variant={view === 'logs' ? 'contained' : 'outlined'}>Logs</PrimaryButton>
+                        <Card sx={{ mt: 3, p: 2 }}>
+                            <Typography variant="h5" fontWeight="bold" sx={{ mb: 2 }}>
+                                Bids
+                            </Typography>
+                            {currentBids.map((bid, index) => (
+                                <Box
+                                    key={index}
+                                    sx={{
+                                        mb: 3,
+                                        p: 2,
+                                        border: '1px solid #ccc',
+                                        borderRadius: 2,
+                                        boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+                                    }}
+                                    onClick={() => navigate(`/admin-procurement-bids/${bid.id}`)} // Kad se klikne na red
+                                >
+                                    <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1 }}>
+                                        Seller: {bid.seller}
+                                    </Typography>
+                                    <Typography variant="body2" sx={{ mb: 1 }}>
+                                        <strong>Price:</strong> {bid.price} BAM
+                                    </Typography>
+                                    <Typography variant="body2" sx={{ mb: 1 }}>
+                                        <strong>Timeline:</strong> {bid.timeline}
+                                    </Typography>
+                                    <Typography variant="body2" sx={{ mb: 1 }}>
+                                        <strong>Proposal:</strong> {bid.proposal}
+                                    </Typography>
+                                    <Typography variant="body2">
+                                        <strong>Submitted At:</strong> {bid.submitted_at}
+                                    </Typography>
+
                                 </Box>
+                            ))}
 
-                                {view === 'bids' && (
-                                    <>
-                                        {currentBids.map((bid, index) => (
-                                            <Box key={index} sx={{
-                                                mb: 2,
-                                                p: 2,
-                                                border: '1px solid #ccc',
-                                                borderRadius: 2,
-                                                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
-                                            }}>
-                                                <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'bold' }}>Seller: {bid.seller}</Typography>
-                                                <Typography variant="body2" sx={{ mb: 1 }}><strong>Price:</strong> {bid.price}</Typography>
-                                                <Typography variant="body2" sx={{ mb: 1 }}><strong>Timeline:</strong> {bid.timeline}</Typography>
-                                                <Typography variant="body2" sx={{ mb: 1 }}><strong>Proposal:</strong> {bid.proposalText}</Typography>
-                                                <Typography variant="body2" sx={{ mb: 1 }}><strong>Submitted At:</strong> {bid.submittedAt}</Typography>
-                                            </Box>
-                                        ))}
-
-                                        {/* Pagination Controls */}
-                                        {view === 'bids' && (
-                                            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-                                                <PrimaryButton onClick={handlePreviousPage} disabled={currentPage === 1} sx={{ marginRight: 2, textTransform: 'none'}}>Previous</PrimaryButton>
-                                                <PrimaryButton onClick={handleNextPage} disabled={currentPage === Math.ceil(mockBids.length / itemsPerPage)}>Next</PrimaryButton>
-                                            </Box>
-                                        )}
-                                    </>
-                                )}
-
-                                {view === 'logs' && (
-                                    <Box>
-                                        {mockLogs.map((log, index) => (
-                                            <Box key={index} sx={{
-                                                mb: 1, p: 1, border: '1px solid #ccc',
-                                            }}>
-                                                <Typography variant="body2"><strong>Action:</strong> {log.action}</Typography>
-                                                <Typography variant="body2"><strong>Time:</strong> {log.time}</Typography>
-                                                <Typography variant="body2"><strong>User:</strong> {log.user}</Typography>
-                                            </Box>
-                                        ))}
-                                    </Box>
-                                )}
-                            </CardContent>
+                            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+                                <PrimaryButton
+                                    onClick={handlePreviousPage}
+                                    disabled={currentPage === 1}
+                                    sx={{ mr: 2, textTransform: 'none' }}
+                                >
+                                    Previous
+                                </PrimaryButton>
+                                <PrimaryButton
+                                    onClick={handleNextPage}
+                                    disabled={currentPage === Math.ceil(bids.length / itemsPerPage)}
+                                    sx={{ textTransform: 'none' }}
+                                >
+                                    Next
+                                </PrimaryButton>
+                            </Box>
                         </Card>
-                    </Container>
 
-                    <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
-                        <SecondaryButton onClick={handleClose}>
-                            Close Preview
-                        </SecondaryButton>
-                    </Box>
+                        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2, mb: 2 }}>
+                            <SecondaryButton onClick={handleClose}>Close Preview</SecondaryButton>
+                        </Box>
+                    </Container>
                 </Container>
             </Layout>
         );

--- a/src/pages/AdminProcurementRequests.jsx
+++ b/src/pages/AdminProcurementRequests.jsx
@@ -1,0 +1,265 @@
+import React, { useState, useEffect } from "react";
+import { useTheme } from "@mui/material/styles";
+import Layout from "../components/Layout/Layout";
+import CustomSearchInput from "../components/Input/SearchInput";
+import CustomDropdownSelect from "../components/Input/DropdownSelect";
+import CustomTextField from "../components/Input/TextField";
+import PrimaryButton from "../components/Button/PrimaryButton";
+import CustomPagination from "../components/Pagination/CustomPagination";
+import CustomInput from "../components/Input/CustomInput";
+import { Eye, Flag, ChevronLeft, ChevronRight } from "lucide-react";
+import "../styles/Admin.css";
+import "../styles/AdminProcurementRequests.css";
+
+const dummyRequests = [
+  {
+    id: 1,
+    title: "Office Chairs",
+    description: "Need ergonomic office chairs",
+    category: "Furniture",
+    status: "active",
+    deadline: "2025-05-01",
+    bids: 3,
+    logs: 5,
+    buyerEmail: "john@example.com",
+    flagged: true,
+  },
+  {
+    id: 2,
+    title: "Laptops for IT",
+    description: "15 laptops with SSD",
+    category: "Electronics",
+    status: "closed",
+    deadline: "2025-04-15",
+    bids: 10,
+    logs: 7,
+    buyerEmail: "anna@example.com",
+    flagged: false,
+  },
+  {
+    id: 3,
+    title: "Cleaning Service",
+    description: "Monthly cleaning contract",
+    category: "Services",
+    status: "awarded",
+    deadline: "2025-04-20",
+    bids: 5,
+    logs: 8,
+    buyerEmail: "lisa@example.com",
+    flagged: true,
+  },
+];
+
+const statusOptions = [
+  { value: "", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "closed", label: "Closed" },
+  { value: "frozen", label: "Frozen" },
+  { value: "awarded", label: "Awarded" },
+];
+
+
+const AdminProcurementDashboard = () => {
+    const [requests, setRequests] = useState(dummyRequests);
+    const [statusFilter, setStatusFilter] = useState("");
+    const [emailSearch, setEmailSearch] = useState("");
+    const [currentPage, setCurrentPage] = useState(1);
+    const requestsPerPage = 5;
+    const [dateFrom, setDateFrom] = useState("");
+    const [dateTo, setDateTo] = useState("");
+    const [bidsFrom, setBidsFrom] = useState(0);
+    const [bidsTo, setBidsTo] = useState(0);
+    const [logsFrom, setLogsFrom] = useState(0);
+    const [logsTo, setLogsTo] = useState(0);
+    const [sidebarOpen, setSidebarOpen] = useState(true); 
+  const theme = useTheme();
+
+  const filteredRequests = requests
+    .filter((req) => 
+      req.buyerEmail.toLowerCase().includes(emailSearch.toLowerCase())
+    )
+    .filter((req) => 
+      statusFilter ? req.status === statusFilter : true
+    )
+    .filter((req) => {
+      // Filtriranje prema opsegu datuma
+      const deadline = new Date(req.deadline);
+      const fromDate = dateFrom ? new Date(dateFrom) : null;
+      const toDate = dateTo ? new Date(dateTo) : null;
+
+      return (
+        (!fromDate || deadline >= fromDate) &&
+        (!toDate || deadline <= toDate)
+      );
+    })
+    .filter((req) => {
+      // Filtriranje prema opsegu broja bidova
+      return (
+        (bidsFrom === 0 || req.bids >= bidsFrom) &&
+        (bidsTo === 0 || req.bids <= bidsTo)
+      );
+    })
+    .filter((req) => {
+      // Filtriranje prema opsegu broja logova
+      return (
+        (logsFrom === 0 || req.logs >= logsFrom) &&
+        (logsTo === 0 || req.logs <= logsTo)
+      );
+    });
+
+  const indexOfLast = currentPage * requestsPerPage;
+  const indexOfFirst = indexOfLast - requestsPerPage;
+  const currentRequests = filteredRequests.slice(indexOfFirst, indexOfLast);
+
+  const handlePageChange = (page) => setCurrentPage(page);
+
+  const handleFreeze = (id) => {
+    //mijenjanje statusa u frozen
+  };
+
+  const toggleSidebar = () => {
+    setSidebarOpen(!sidebarOpen); // toggle sidebar visibility
+  };
+
+  return (
+    <Layout>
+      <div className="dashboard-container" style={{ display: "flex" }}>
+        
+      <div
+            className={`sidebar ${sidebarOpen ? "open" : "closed"}`}
+            style={{
+                backgroundColor: theme.palette.background.paper, // theme color
+            }}
+            >
+            
+            {sidebarOpen && (
+                <div>
+                <h4>Filters</h4>
+                <CustomSearchInput
+                    label="Search by Email"
+                    value={emailSearch}
+                    onChange={(e) => setEmailSearch(e.target.value)}
+                    placeholder="Enter email"
+                />
+                <CustomDropdownSelect
+                    label="Status"
+                    options={statusOptions}
+                    value={statusFilter}
+                    onChange={(e) => setStatusFilter(e.target.value)}
+                />
+
+                <div>
+                    <label>From and To Date</label>
+                    <CustomTextField
+                    type="date"
+                    value={dateFrom}
+                    onChange={(e) => setDateFrom(e.target.value)}
+                    />
+                    <CustomTextField
+                    type="date"
+                    value={dateTo}
+                    onChange={(e) => setDateTo(e.target.value)}
+                    />
+                </div>
+
+                <div>
+                    <label>From and To Bids</label>
+                    <CustomTextField
+                    label="From"
+                    type="number"
+                    value={bidsFrom}
+                    onChange={(e) => setBidsFrom(e.target.value)}
+                    />
+                    <CustomTextField
+                    label="To"
+                    type="number"
+                    value={bidsTo}
+                    onChange={(e) => setBidsTo(e.target.value)}
+                    />
+                </div>
+
+                <div>
+                    <label>From and To Logs</label>
+                    <CustomTextField
+                    label="From"
+                    type="number"
+                    value={logsFrom}
+                    onChange={(e) => setLogsFrom(e.target.value)}
+                    />
+                    <CustomTextField
+                    label="To"
+                    type="number"
+                    value={logsTo}
+                    onChange={(e) => setLogsTo(e.target.value)}
+                    />
+                </div>
+                </div>
+            )}
+        </div>
+        <button onClick={toggleSidebar} className="sidebar-toggle">
+                {sidebarOpen ? <ChevronLeft /> : <ChevronRight />}
+            </button>
+
+        <div className="panel" style={{ flex: 1, backgroundColor: theme.palette.background.default }}>
+          <h3 style={{ color: theme.palette.text.primary }}>Procurement Requests</h3>
+          <table className="table">
+            <thead>
+              <tr>
+                <th className="th">Title</th>
+                <th className="th">Description</th>
+                <th className="th">Category</th>
+                <th className="th">Status</th>
+                <th className="th">Deadline</th>
+                <th className="th">Bids</th>
+                <th className="th">Logs</th>
+                <th className="th">Buyer Email</th>
+                <th className="th">Flags</th>
+              </tr>
+            </thead>
+            <tbody>
+              {currentRequests.map((req) => (
+                <tr
+                  key={req.id}
+                  className="tr"
+                  onClick={() => alert("View " + req.id)} // Kada se klikne na red
+                  style={{ cursor: "pointer" }}
+                >
+                  <td className="td">{req.title}</td>
+                  <td className="td">{req.description}</td>
+                  <td className="td">{req.category}</td>
+                  <td className="td">{req.status}</td>
+                  <td className="td">{req.deadline}</td>
+                  <td className="td">{req.bids}</td>
+                  <td className="td">{req.logs}</td>
+                  <td className="td">{req.buyerEmail}</td>
+                  <td className="td">
+                    {req.flagged && <Flag color="red" size={20} />}
+                  </td>
+                  <td className="td">
+                    <PrimaryButton onClick={() => handleFreeze(req.id)}>
+                      Freeze
+                    </PrimaryButton>
+                  </td>
+                </tr>
+              ))}
+              {currentRequests.length === 0 && (
+                <tr>
+                  <td className="td" colSpan="10">
+                    No requests found.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+          <CustomPagination
+            currentPage={currentPage}
+            totalPages={Math.ceil(filteredRequests.length / requestsPerPage)}
+            onPageChange={handlePageChange}
+          />
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default AdminProcurementDashboard;

--- a/src/pages/AdminProcurementRequests.jsx
+++ b/src/pages/AdminProcurementRequests.jsx
@@ -10,6 +10,8 @@ import CustomInput from "../components/Input/CustomInput";
 import { Eye, Flag, ChevronLeft, ChevronRight } from "lucide-react";
 import "../styles/Admin.css";
 import "../styles/AdminProcurementRequests.css";
+import {useNavigate, useParams} from "react-router-dom";
+
 
 const dummyRequests = [
   {
@@ -77,6 +79,9 @@ const AdminProcurementDashboard = () => {
     const [logsError, setLogsError] = useState("");
  
     const theme = useTheme();
+
+  const navigate = useNavigate();
+
 
   const filteredRequests = requests
     .filter((req) => 
@@ -302,7 +307,7 @@ useEffect(() => {
                 <tr
                   key={req.id}
                   className="tr"
-                  onClick={() => alert("View " + req.id)} // Kada se klikne na red
+                  onClick={() => navigate(`/admin-procurement-requests/${req.id}`)} // Kada se klikne na red
                   style={{ cursor: "pointer" }}
                 >
                   <td className="td">{req.title}</td>

--- a/src/pages/AdminProcurementRequests.jsx
+++ b/src/pages/AdminProcurementRequests.jsx
@@ -136,40 +136,40 @@ const AdminProcurementDashboard = () => {
     setSidebarOpen(!sidebarOpen); // toggle sidebar visibility
   };
 
-  useEffect(() => {
-    let isValid = true;
-  
-    // Date validation
-    if (dateFrom && dateTo && new Date(dateFrom) > new Date(dateTo)) {
-      setDateError("Start date must be earlier than or equal to end date.");
-      isValid = false;
-    } else {
-      setDateError("");
-    }
-  
-    // Bids validation
-    if ((bidsFrom && bidsFrom < 0) || (bidsTo && bidsTo < 0)) {
-      setBidsError("Number of bids cannot be negative.");
-      isValid = false;
-    } else if (bidsFrom && bidsTo && Number(bidsFrom) > Number(bidsTo)) {
-      setBidsError("Minimum number of bids must be less than or equal to maximum.");
-      isValid = false;
-    } else {
-      setBidsError("");
-    }
-  
-    // Logs validation
-    if ((logsFrom && logsFrom < 0) || (logsTo && logsTo < 0)) {
-      setLogsError("Number of logs cannot be negative.");
-      isValid = false;
-    } else if (logsFrom && logsTo && Number(logsFrom) > Number(logsTo)) {
-      setLogsError("Minimum number of logs must be less than or equal to maximum.");
-      isValid = false;
-    } else {
-      setLogsError("");
-    }
-  }, [dateFrom, dateTo, bidsFrom, bidsTo, logsFrom, logsTo]);
-  
+useEffect(() => {
+  let isValid = true;
+
+  // Date validation
+  if (dateFrom && dateTo && new Date(dateFrom) > new Date(dateTo)) {
+    setDateError("Start date must be earlier than or equal to end date.");
+    isValid = false;
+  } else {
+    setDateError("");
+  }
+
+  // Bids validation
+  if ((bidsFrom && bidsFrom < 0) || (bidsTo && bidsTo < 0)) {
+    setBidsError("Number of bids cannot be negative.");
+    isValid = false;
+  } else if (bidsFrom && bidsTo && Number(bidsFrom) > Number(bidsTo)) {
+    setBidsError("Minimum number of bids must be less than or equal to maximum.");
+    isValid = false;
+  } else {
+    setBidsError("");
+  }
+
+  // Logs validation
+  if ((logsFrom && logsFrom < 0) || (logsTo && logsTo < 0)) {
+    setLogsError("Number of logs cannot be negative.");
+    isValid = false;
+  } else if (logsFrom && logsTo && Number(logsFrom) > Number(logsTo)) {
+    setLogsError("Minimum number of logs must be less than or equal to maximum.");
+    isValid = false;
+  } else {
+    setLogsError("");
+  }
+}, [dateFrom, dateTo, bidsFrom, bidsTo, logsFrom, logsTo]);
+
   
 
   return (
@@ -186,68 +186,77 @@ const AdminProcurementDashboard = () => {
             {sidebarOpen && (
                 <div>
                 <h4>Filters</h4>
-                <CustomSearchInput
-                    label="Search by Email"
-                    value={emailSearch}
-                    onChange={(e) => setEmailSearch(e.target.value)}
-                    placeholder="Enter email"
-                />
-                <CustomDropdownSelect
-                    label="Status"
-                    options={statusOptions}
-                    value={statusFilter}
-                    onChange={(e) => setStatusFilter(e.target.value)}
-                />
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0px' }}>
+                <div style={{ marginBottom: '-15px' }}>
+        <CustomSearchInput
+            label="Search by Email"
+            value={emailSearch}
+            onChange={(e) => setEmailSearch(e.target.value)}
+            placeholder="Enter email"
+        />
+    </div>
+    <div>
+        <CustomDropdownSelect
+            label="Status"
+            options={statusOptions}
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+        />
+    </div>
 
-                <div>
-                    <label>From and To Date</label>
-                    <CustomTextField
-                    type="date"
-                    value={dateFrom}
-                    onChange={(e) => setDateFrom(e.target.value)}
-                    />
-                    <CustomTextField
-                    type="date"
-                    value={dateTo}
-                    onChange={(e) => setDateTo(e.target.value)}
-                    />
-                    {dateError && (<div style={{ color: "red", fontSize: "0.875rem" }}>{dateError}</div>)}
-                </div>
+    <div>
+        <label style={{ marginBottom: '-8px', display: 'block' }}>From and To Date</label>
+        <CustomTextField
+            type="date"
+            value={dateFrom}
+            onChange={(e) => setDateFrom(e.target.value)}
+            style={{ marginBottom: '-5px' }}
+        />
+        <CustomTextField
+            type="date"
+            value={dateTo}
+            onChange={(e) => setDateTo(e.target.value)}
+        />
+        {dateError && (<div style={{ color: "red", fontSize: "0.875rem" }}>{dateError}</div>)}
+    </div>
+    <div>
+        <label style={{ marginBottom: '-8px', display: 'block' }}>Bids</label>
+        <div style={{ display: 'flex', gap: '0px' }}>
+            <CustomTextField
+                label="From"
+                type="number"
+                value={bidsFrom}
+                onChange={(e) => setBidsFrom(e.target.value)}
+            />
+            <CustomTextField
+                label="To"
+                type="number"
+                value={bidsTo}
+                onChange={(e) => setBidsTo(e.target.value)}
+            />
+        </div>
+        {bidsError && (<div style={{ color: "red", fontSize: "0.875rem" }}>{bidsError}</div>)}
+    </div>
 
-                <div>
-                    <label>Bids</label>
-                    <CustomTextField
-                    label="From"
-                    type="number"
-                    value={bidsFrom}
-                    onChange={(e) => setBidsFrom(e.target.value)}
-                    />
-                    <CustomTextField
-                    label="To"
-                    type="number"
-                    value={bidsTo}
-                    onChange={(e) => setBidsTo(e.target.value)}
-                    />
-                    {bidsError && (<div style={{ color: "red", fontSize: "0.875rem" }}>{bidsError}</div>)}
-                </div>
-
-                <div>
-                    <label>Logs</label>
-                    <CustomTextField
-                    label="From"
-                    type="number"
-                    value={logsFrom}
-                    onChange={(e) => setLogsFrom(e.target.value)}
-                    />
-                    <CustomTextField
-                    label="To"
-                    type="number"
-                    value={logsTo}
-                    onChange={(e) => setLogsTo(e.target.value)}
-                    />
-                    {logsError && (<div style={{ color: "red", fontSize: "0.875rem" }}>{logsError}</div>)}
-                </div>
-                <PrimaryButton
+    <div>
+        <label style={{ marginBottom: '-8px', display: 'block' }}>Logs</label>
+        <div style={{ display: 'flex', gap: '0px' }}>
+            <CustomTextField
+                label="From"
+                type="number"
+                value={logsFrom}
+                onChange={(e) => setLogsFrom(e.target.value)}
+            />
+            <CustomTextField
+                label="To"
+                type="number"
+                value={logsTo}
+                onChange={(e) => setLogsTo(e.target.value)}
+            />
+        </div>
+        {logsError && (<div style={{ color: "red", fontSize: "0.875rem" }}>{logsError}</div>)}
+    </div>
+    <PrimaryButton
                     onClick={() => {
                         setEmailSearch("");
                         setStatusFilter("");
@@ -258,10 +267,12 @@ const AdminProcurementDashboard = () => {
                         setLogsFrom("");
                         setLogsTo("");
                     }}
-                    style={{ marginTop: "20px" }}
+                    style={{ marginTop: "5px" }}
                     >
                     Clear Filters
                 </PrimaryButton>
+</div>
+                
 
                 </div>
             )}
@@ -296,12 +307,13 @@ const AdminProcurementDashboard = () => {
                 >
                   <td className="td">{req.title}</td>
                   <td className="td">{req.description}</td>
-                  <td className="td">{req.category}</td>
-                  <td className="td">{req.status}</td>
-                  <td className="td">{req.deadline}</td>
-                  <td className="td">{req.bids}</td>
-                  <td className="td">{req.logs}</td>
-                  <td className="td">{req.buyerEmail}</td>
+                  <td className="td td-center">{req.category}</td>
+                  <td className="td td-center">{req.status}</td>
+                  <td className="td td-center">{req.deadline}</td>
+                  <td className="td td-center">{req.bids}</td>
+                  <td className="td td-center">{req.logs}</td>
+                  <td className="td td-center">{req.buyerEmail}</td>
+
                   <td className="td">
                     {req.flagged && <Flag color="red" size={20} />}
                   </td>

--- a/src/pages/AdminProcurementRequests.jsx
+++ b/src/pages/AdminProcurementRequests.jsx
@@ -67,12 +67,16 @@ const AdminProcurementDashboard = () => {
     const requestsPerPage = 5;
     const [dateFrom, setDateFrom] = useState("");
     const [dateTo, setDateTo] = useState("");
-    const [bidsFrom, setBidsFrom] = useState(0);
-    const [bidsTo, setBidsTo] = useState(0);
-    const [logsFrom, setLogsFrom] = useState(0);
-    const [logsTo, setLogsTo] = useState(0);
-    const [sidebarOpen, setSidebarOpen] = useState(true); 
-  const theme = useTheme();
+    const [bidsFrom, setBidsFrom] = useState("");
+    const [bidsTo, setBidsTo] = useState("");
+    const [logsFrom, setLogsFrom] = useState("");
+    const [logsTo, setLogsTo] = useState("");    
+    const [sidebarOpen, setSidebarOpen] = useState(true);
+    const [dateError, setDateError] = useState("");
+    const [bidsError, setBidsError] = useState("");
+    const [logsError, setLogsError] = useState("");
+ 
+    const theme = useTheme();
 
   const filteredRequests = requests
     .filter((req) => 
@@ -93,19 +97,30 @@ const AdminProcurementDashboard = () => {
       );
     })
     .filter((req) => {
-      // Filtriranje prema opsegu broja bidova
-      return (
-        (bidsFrom === 0 || req.bids >= bidsFrom) &&
-        (bidsTo === 0 || req.bids <= bidsTo)
-      );
-    })
-    .filter((req) => {
-      // Filtriranje prema opsegu broja logova
-      return (
-        (logsFrom === 0 || req.logs >= logsFrom) &&
-        (logsTo === 0 || req.logs <= logsTo)
-      );
-    });
+        const from = bidsFrom !== "" ? Number(bidsFrom) : null;
+        const to = bidsTo !== "" ? Number(bidsTo) : null;
+      
+        if ((from != null && from < 0) || (to != null && to < 0)) return false;
+        if (from != null && to != null && from > to) return false;
+      
+        return (
+          (from == null || req.bids >= from) &&
+          (to == null || req.bids <= to)
+        );
+      })
+      .filter((req) => {
+        const from = logsFrom !== "" ? Number(logsFrom) : null;
+        const to = logsTo !== "" ? Number(logsTo) : null;
+      
+        if ((from != null && from < 0) || (to != null && to < 0)) return false;
+        if (from != null && to != null && from > to) return false;
+      
+        return (
+          (from == null || req.logs >= from) &&
+          (to == null || req.logs <= to)
+        );
+      })
+      
 
   const indexOfLast = currentPage * requestsPerPage;
   const indexOfFirst = indexOfLast - requestsPerPage;
@@ -120,6 +135,42 @@ const AdminProcurementDashboard = () => {
   const toggleSidebar = () => {
     setSidebarOpen(!sidebarOpen); // toggle sidebar visibility
   };
+
+  useEffect(() => {
+    let isValid = true;
+  
+    // Date validation
+    if (dateFrom && dateTo && new Date(dateFrom) > new Date(dateTo)) {
+      setDateError("Start date must be earlier than or equal to end date.");
+      isValid = false;
+    } else {
+      setDateError("");
+    }
+  
+    // Bids validation
+    if ((bidsFrom && bidsFrom < 0) || (bidsTo && bidsTo < 0)) {
+      setBidsError("Number of bids cannot be negative.");
+      isValid = false;
+    } else if (bidsFrom && bidsTo && Number(bidsFrom) > Number(bidsTo)) {
+      setBidsError("Minimum number of bids must be less than or equal to maximum.");
+      isValid = false;
+    } else {
+      setBidsError("");
+    }
+  
+    // Logs validation
+    if ((logsFrom && logsFrom < 0) || (logsTo && logsTo < 0)) {
+      setLogsError("Number of logs cannot be negative.");
+      isValid = false;
+    } else if (logsFrom && logsTo && Number(logsFrom) > Number(logsTo)) {
+      setLogsError("Minimum number of logs must be less than or equal to maximum.");
+      isValid = false;
+    } else {
+      setLogsError("");
+    }
+  }, [dateFrom, dateTo, bidsFrom, bidsTo, logsFrom, logsTo]);
+  
+  
 
   return (
     <Layout>
@@ -160,10 +211,11 @@ const AdminProcurementDashboard = () => {
                     value={dateTo}
                     onChange={(e) => setDateTo(e.target.value)}
                     />
+                    {dateError && (<div style={{ color: "red", fontSize: "0.875rem" }}>{dateError}</div>)}
                 </div>
 
                 <div>
-                    <label>From and To Bids</label>
+                    <label>Bids</label>
                     <CustomTextField
                     label="From"
                     type="number"
@@ -176,10 +228,11 @@ const AdminProcurementDashboard = () => {
                     value={bidsTo}
                     onChange={(e) => setBidsTo(e.target.value)}
                     />
+                    {bidsError && (<div style={{ color: "red", fontSize: "0.875rem" }}>{bidsError}</div>)}
                 </div>
 
                 <div>
-                    <label>From and To Logs</label>
+                    <label>Logs</label>
                     <CustomTextField
                     label="From"
                     type="number"
@@ -192,7 +245,24 @@ const AdminProcurementDashboard = () => {
                     value={logsTo}
                     onChange={(e) => setLogsTo(e.target.value)}
                     />
+                    {logsError && (<div style={{ color: "red", fontSize: "0.875rem" }}>{logsError}</div>)}
                 </div>
+                <PrimaryButton
+                    onClick={() => {
+                        setEmailSearch("");
+                        setStatusFilter("");
+                        setDateFrom("");
+                        setDateTo("");
+                        setBidsFrom("");
+                        setBidsTo("");
+                        setLogsFrom("");
+                        setLogsTo("");
+                    }}
+                    style={{ marginTop: "20px" }}
+                    >
+                    Clear Filters
+                </PrimaryButton>
+
                 </div>
             )}
         </div>

--- a/src/pages/AdminProcurementRequests.jsx
+++ b/src/pages/AdminProcurementRequests.jsx
@@ -15,46 +15,6 @@ import axios from 'axios';
 import { isAuthenticated, isAdmin } from "../utils/auth.jsx";
 
 
-
-const dummyRequests = [
-  {
-    id: 1,
-    title: "Office Chairs",
-    description: "Need ergonomic office chairs",
-    category: "Furniture",
-    status: "active",
-    deadline: "2025-05-01",
-    bids: 3,
-    logs: 5,
-    buyerEmail: "john@example.com",
-    flagged: true,
-  },
-  {
-    id: 2,
-    title: "Laptops for IT",
-    description: "15 laptops with SSD",
-    category: "Electronics",
-    status: "closed",
-    deadline: "2025-04-15",
-    bids: 10,
-    logs: 7,
-    buyerEmail: "anna@example.com",
-    flagged: false,
-  },
-  {
-    id: 3,
-    title: "Cleaning Service",
-    description: "Monthly cleaning contract",
-    category: "Services",
-    status: "awarded",
-    deadline: "2025-04-20",
-    bids: 5,
-    logs: 8,
-    buyerEmail: "lisa@example.com",
-    flagged: true,
-  },
-];
-
 const statusOptions = [
   { value: "", label: "All" },
   { value: "active", label: "Active" },
@@ -250,7 +210,7 @@ useEffect(() => {
 
   return (
     <Layout>
-      <div className="dashboard-container" style={{ display: "flex" }}>
+      <div className="admin-procurement-requests" style={{ display: "flex" }}>
         
       <div
             className={`sidebar ${sidebarOpen ? "open" : "closed"}`}

--- a/src/pages/BidLogs.jsx
+++ b/src/pages/BidLogs.jsx
@@ -1,0 +1,138 @@
+import { useNavigate, useParams } from "react-router-dom";
+import React, { useState, useEffect } from "react";
+import Layout from "../components/Layout/Layout.jsx";
+import { Box, Container, Typography, Card, CircularProgress } from "@mui/material";
+import SecondaryButton from "../components/Button/SecondaryButton.jsx";
+
+const BidLogs = () => {
+    const navigate = useNavigate();
+    const { id } = useParams();
+    const [data, setData] = useState(null);
+    const [loading, setLoading] = useState(true);
+
+    const handleClose = () => {
+        console.log('Return to procurement preview!');
+        navigate(-1);
+    };
+
+    // Mock data
+    const mockData = [
+        {
+            id: 2,
+            seller: "Jane Smith",
+            price: 2000,
+            timeline: "2023-11-01 - 2023-11-10",
+            proposal: "Advanced Proposal",
+            submitted_at: "2023-11-01T10:00:00Z",
+            adminLogs: [
+                { action: "Bid submitted", created_at: "2023-11-01T10:00:00Z" },
+                { action: "Bid updated", created_at: "2023-11-02T12:00:00Z" }
+            ],
+            evaluations: [
+                { score: 9 }
+            ]
+        },
+        {
+            id: 1,
+            seller: "John Doe",
+            price: 1500,
+            timeline: "2023-10-01 - 2023-10-10",
+            proposal: "Basic Proposal",
+            submitted_at: "2023-10-01T12:00:00Z",
+            adminLogs: [
+                { action: "Bid submitted", created_at: "2023-10-01T12:00:00Z" },
+                { action: "Bid updated", created_at: "2023-10-02T14:00:00Z" }
+            ],
+            evaluations: [
+                { score: 8 }
+            ]
+        }
+    ];
+
+    useEffect(() => {
+        setLoading(true);
+        setTimeout(() => {
+            const selectedBid = mockData.find(bid => bid.id === parseInt(id));
+            if (selectedBid) {
+                setData(selectedBid);
+            } else {
+                setData({ notFound: true });
+            }
+            setLoading(false);
+        }, 300);
+    }, [id]);
+
+    if (loading) {
+        return (
+            <Layout>
+                <Container maxWidth="md" sx={{ mt: 4 }}>
+                    <Box display="flex" justifyContent="center">
+                        <CircularProgress />
+                    </Box>
+                </Container>
+            </Layout>
+        );
+    }
+
+    if (data?.notFound) {
+        return (
+            <Layout>
+                <Container maxWidth="md" sx={{ mt: 4 }}>
+                    <Typography variant="h6" color="error">Bid not found!</Typography>
+                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+                        <SecondaryButton onClick={handleClose}>Return to procurement</SecondaryButton>
+                    </Box>
+                </Container>
+            </Layout>
+        );
+    }
+
+    return (
+        <Layout>
+            <Container maxWidth="md">
+                <Card sx={{ p: 3, mt: 4 }}>
+                    <Typography variant="h5" fontWeight="bold" gutterBottom>
+                        Bid Details
+                    </Typography>
+                    <Typography variant="body1"><strong>Seller:</strong> {data.seller}</Typography>
+                    <Typography variant="body1"><strong>Price:</strong> ${data.price}</Typography>
+                    <Typography variant="body1"><strong>Timeline:</strong> {data.timeline}</Typography>
+                    <Typography variant="body1"><strong>Proposal:</strong> {data.proposal}</Typography>
+                    <Typography variant="body1">
+                        <strong>Submitted At:</strong> {data.submitted_at ? new Date(data.submitted_at).toLocaleString() : "N/A"}
+                    </Typography>
+
+                    <Typography variant="h6" fontWeight="bold" sx={{ mt: 4 }}>
+                        Admin Logs
+                    </Typography>
+                    {data.adminLogs.map((log, index) => (
+                        <Box key={index} sx={{ mb: 2, border: '1px solid #ddd', padding: 2, borderRadius: 1 }}>
+                            <Typography variant="body2">
+                                {log.action} - {new Date(log.created_at).toLocaleString()}
+                            </Typography>
+                        </Box>
+                    ))}
+
+                    <Typography variant="h6" fontWeight="bold" sx={{ mt: 4 }}>
+                        Evaluations
+                    </Typography>
+                    {data.evaluations.map((evalItem, index) => (
+                        <Box key={index} sx={{ mb: 2, border: '1px solid #ddd', padding: 2, borderRadius: 1 }}>
+                            <Typography variant="body2">
+                                Score: {evalItem.score}
+                            </Typography>
+                        </Box>
+                    ))}
+
+                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 4 }}>
+                        <SecondaryButton onClick={handleClose}>Return to procurement</SecondaryButton>
+                    </Box>
+                </Card>
+            </Container>
+        </Layout>
+    );
+};
+
+export default BidLogs;
+
+

--- a/src/pages/BidLogs.jsx
+++ b/src/pages/BidLogs.jsx
@@ -3,64 +3,49 @@ import React, { useState, useEffect } from "react";
 import Layout from "../components/Layout/Layout.jsx";
 import { Box, Container, Typography, Card, CircularProgress } from "@mui/material";
 import SecondaryButton from "../components/Button/SecondaryButton.jsx";
+import { isAuthenticated, isAdmin } from "../utils/auth.jsx";
+import axios from "axios";
 
 const BidLogs = () => {
     const navigate = useNavigate();
-    const { id } = useParams();
-    const [data, setData] = useState(null);
+    const token = localStorage.getItem("token");
+    const [data, setData] = useState([]); // Initialize as an array
+    const {requestId, bidId } = useParams(); // Get both requestId and bidId
     const [loading, setLoading] = useState(true);
 
+    console.log("RequestID i BidId:", requestId, bidId);
     const handleClose = () => {
         console.log('Return to procurement preview!');
         navigate(-1);
     };
 
-    // Mock data
-    const mockData = [
-        {
-            id: 2,
-            seller: "Jane Smith",
-            price: 2000,
-            timeline: "2023-11-01 - 2023-11-10",
-            proposal: "Advanced Proposal",
-            submitted_at: "2023-11-01T10:00:00Z",
-            adminLogs: [
-                { action: "Bid submitted", created_at: "2023-11-01T10:00:00Z" },
-                { action: "Bid updated", created_at: "2023-11-02T12:00:00Z" }
-            ],
-            evaluations: [
-                { score: 9 }
-            ]
-        },
-        {
-            id: 1,
-            seller: "John Doe",
-            price: 1500,
-            timeline: "2023-10-01 - 2023-10-10",
-            proposal: "Basic Proposal",
-            submitted_at: "2023-10-01T12:00:00Z",
-            adminLogs: [
-                { action: "Bid submitted", created_at: "2023-10-01T12:00:00Z" },
-                { action: "Bid updated", created_at: "2023-10-02T14:00:00Z" }
-            ],
-            evaluations: [
-                { score: 8 }
-            ]
-        }
-    ];
-
     useEffect(() => {
-        setLoading(true);
-        setTimeout(() => {
-            const selectedBid = mockData.find(bid => bid.id === parseInt(id));
-            if (selectedBid) {
-                setData(selectedBid);
+        if (!isAdmin()) {
+            if (!isAuthenticated()) {
+                window.location.href = "/login";
             } else {
-                setData({ notFound: true });
+                window.location.href = "/";
             }
-            setLoading(false);
-        }, 300);
-    }, [id]);
+            return;
+        }
+
+        // Fetch all bids for the requestId
+        axios.get(`${import.meta.env.VITE_API_URL}/api/admin/procurement-bids/${requestId}`, {
+            headers: {
+                Authorization: `Bearer ${token}`, // Attach the JWT token here
+            },
+        })
+            .then((response) => {
+                console.log("Fetched all bid data for request:", response.data);
+                setData(response.data); // Set data here
+                setLoading(false);
+            })
+            .catch((error) => {
+                console.error("Error fetching bid data:", error);
+                setData({ notFound: true });
+                setLoading(false);
+            });
+    }, [requestId]);
 
     if (loading) {
         return (
@@ -87,52 +72,75 @@ const BidLogs = () => {
         );
     }
 
+    console.log("Data to render:", data);  // Check the data structure here
+
+    // nadji bid da matcha id-ju
+    const bid = data[parseInt(bidId) - 1];
+
+    if (!bid) {
+        return (
+            <Layout>
+                <Container maxWidth="md" sx={{ mt: 4 }}>
+                    <Typography variant="h6" color="error">No matching bid found.</Typography>
+                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+                        <SecondaryButton onClick={handleClose}>Return to procurement</SecondaryButton>
+                    </Box>
+                </Container>
+            </Layout>
+        );
+    }
+
     return (
         <Layout>
             <Container maxWidth="md">
+                <Typography variant="h5" fontWeight="bold" gutterBottom>
+                    Bid Details
+                </Typography>
+                {/* Display the specific bid */}
                 <Card sx={{ p: 3, mt: 4 }}>
-                    <Typography variant="h5" fontWeight="bold" gutterBottom>
-                        Bid Details
-                    </Typography>
-                    <Typography variant="body1"><strong>Seller:</strong> {data.seller}</Typography>
-                    <Typography variant="body1"><strong>Price:</strong> ${data.price}</Typography>
-                    <Typography variant="body1"><strong>Timeline:</strong> {data.timeline}</Typography>
-                    <Typography variant="body1"><strong>Proposal:</strong> {data.proposal}</Typography>
+                    <Typography variant="body1"><strong>Seller:</strong> {bid.seller}</Typography>
+                    <Typography variant="body1"><strong>Price:</strong> ${bid.price}</Typography>
+                    <Typography variant="body1"><strong>Timeline:</strong> {bid.timeline}</Typography>
+                    <Typography variant="body1"><strong>Proposal:</strong> {bid.proposal}</Typography>
                     <Typography variant="body1">
-                        <strong>Submitted At:</strong> {data.submitted_at ? new Date(data.submitted_at).toLocaleString() : "N/A"}
+                        <strong>Submitted At:</strong> {bid.submitted_at ? new Date(bid.submitted_at).toLocaleString() : "N/A"}
                     </Typography>
 
                     <Typography variant="h6" fontWeight="bold" sx={{ mt: 4 }}>
                         Admin Logs
                     </Typography>
-                    {data.adminLogs.map((log, index) => (
-                        <Box key={index} sx={{ mb: 2, border: '1px solid #ddd', padding: 2, borderRadius: 1 }}>
-                            <Typography variant="body2">
-                                {log.action} - {new Date(log.created_at).toLocaleString()}
-                            </Typography>
-                        </Box>
-                    ))}
+                    {bid.adminLogs && bid.adminLogs.length > 0 ? (
+                        bid.adminLogs.map((log, logIndex) => (
+                            <Box key={logIndex} sx={{ mb: 2, border: '1px solid #ddd', padding: 2, borderRadius: 1 }}>
+                                <Typography variant="body2">
+                                    {log.action} - {new Date(log.created_at).toLocaleString()}
+                                </Typography>
+                            </Box>
+                        ))
+                    ) : (
+                        <Typography variant="body2">No admin logs available</Typography>
+                    )}
 
                     <Typography variant="h6" fontWeight="bold" sx={{ mt: 4 }}>
                         Evaluations
                     </Typography>
-                    {data.evaluations.map((evalItem, index) => (
-                        <Box key={index} sx={{ mb: 2, border: '1px solid #ddd', padding: 2, borderRadius: 1 }}>
+                    {bid.score !== null ? (
+                        <Box sx={{ mb: 2, border: '1px solid #ddd', padding: 2, borderRadius: 1 }}>
                             <Typography variant="body2">
-                                Score: {evalItem.score}
+                                Score: {bid.score}
                             </Typography>
                         </Box>
-                    ))}
-
-                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 4 }}>
-                        <SecondaryButton onClick={handleClose}>Return to procurement</SecondaryButton>
-                    </Box>
+                    ) : (
+                        <Typography variant="body2">No evaluations available</Typography>
+                    )}
                 </Card>
+
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 4 }}>
+                    <SecondaryButton onClick={handleClose}>Return to procurement</SecondaryButton>
+                </Box>
             </Container>
         </Layout>
     );
 };
 
 export default BidLogs;
-
-

--- a/src/pages/CreateUserPage.jsx
+++ b/src/pages/CreateUserPage.jsx
@@ -203,26 +203,6 @@ const CreateUserPage = () => {
           "Company name can only contain letters, numbers, spaces, and certain special characters",
       },
     ],
-    company_name: [
-      {
-        test: (value) => formData.role === "admin" || !!value,
-        message: "Company name is required",
-      },
-      {
-        test: (value) => formData.role === "admin" || value.length >= 2,
-        message: "Company name must be at least 2 characters long",
-      },
-      {
-        test: (value) => formData.role === "admin" || value.length <= 50,
-        message: "Company name cannot exceed 50 characters",
-      },
-      {
-        test: (value) =>
-          formData.role === "admin" || /^[A-Za-z0-9\s,.-]+$/.test(value),
-        message:
-          "Company name can only contain letters, numbers, spaces, and certain special characters",
-      },
-    ],
     company_address: [
       {
         test: (value) => formData.role === "admin" || !!value,

--- a/src/styles/AdminProcurementRequests.css
+++ b/src/styles/AdminProcurementRequests.css
@@ -59,7 +59,9 @@
   .table th, .table td {
     padding: 10px;
   }
-  
+  .table .td-center{
+    text-align: center;
+  }
   .table td {
     text-align: left;
   }
@@ -73,4 +75,3 @@
     padding: 20px;
     background: #f8f8f8;
   }
-  

--- a/src/styles/AdminProcurementRequests.css
+++ b/src/styles/AdminProcurementRequests.css
@@ -58,11 +58,6 @@
   
   .table th, .table td {
     padding: 10px;
-    border: 1px solid #ddd; /* Ovo je osnovna boja, dinamičke boje za pozadinu i tekst idu u JSX */
-  }
-  
-  .table th {
-    background-color: #f2f2f2;
   }
   
   .table td {

--- a/src/styles/AdminProcurementRequests.css
+++ b/src/styles/AdminProcurementRequests.css
@@ -1,5 +1,5 @@
 /* Admin.css */
-.dashboard-container {
+.admin-procurement-requests{
     display: flex;
     flex-direction: row; /* Promeni na 'row' da bi sidebar i tabla bili u istom redu */
     align-items: flex-start; /* Poravnaj elemente na početak */

--- a/src/styles/AdminProcurementRequests.css
+++ b/src/styles/AdminProcurementRequests.css
@@ -1,0 +1,81 @@
+/* Admin.css */
+.dashboard-container {
+    display: flex;
+    flex-direction: row; /* Promeni na 'row' da bi sidebar i tabla bili u istom redu */
+    align-items: flex-start; /* Poravnaj elemente na početak */
+    justify-content: flex-start; /* Nema potrebe za centriranjem */
+    height: 100vh;
+    width: 100vw;
+    background-color: #f8f9fa;
+    padding: 20px;
+    box-sizing: border-box;
+    position: relative;
+  }
+  
+
+
+  .sidebar {
+    width: 200px;
+    transition: width 0.3s ease;
+    padding: 10px;
+    overflow: hidden;
+  }
+  
+  .sidebar.closed {
+    width: 0;
+    padding: 0;
+  }
+  
+  /* Position button relative to dashboard container */
+  .sidebar-toggle {
+    position: absolute;
+    top: 30px;
+    left: 10px; /* Distance from left edge of dashboard */
+    z-index: 100;
+    background: none;
+    border: none;
+    cursor: pointer;
+    transition: left 0.3s ease;
+  }
+  
+  /* When sidebar is open, move button */
+  .sidebar.open ~ .sidebar-toggle {
+    left: 210px; /* Width of sidebar + some padding */
+  }
+  
+  .panel {
+    flex: 1; /* Ovaj element treba da zauzme preostali prostor */
+    padding: 20px;
+    background-color: #fff;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+    text-align: center;
+    overflow-y: auto;
+  }
+  .table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  
+  .table th, .table td {
+    padding: 10px;
+    border: 1px solid #ddd; /* Ovo je osnovna boja, dinamičke boje za pozadinu i tekst idu u JSX */
+  }
+  
+  .table th {
+    background-color: #f2f2f2;
+  }
+  
+  .table td {
+    text-align: left;
+  }
+  
+  .row-container {
+    display: flex;
+  }
+  
+  .left-column-fixed {
+    width: 250px;
+    padding: 20px;
+    background: #f8f8f8;
+  }
+  


### PR DESCRIPTION
Made another dashboard for admin to view all procurement requests. Added a button to the navbar to take him there. On the main page there is a table of procurement requests with some basic information as well as a filter sidebar that can be closed and opened by clicking the arrow. Admin can click on a row in the requests table and view a detailed preview of the request. on the bottom of that page are all of the bids associated with the request , and when you click on a bid, it shows the logs for that bid. On the main table page, before calling a route to fetch the list of procurement requests, first an alert service route is called to check for unusual behaviour and create alerts in the database and turn attribute flagged to true for the request, if needed. If flagged is true, a flag icon will show up next to the request in question. The actual alert text will show up displayed in the preview. When admin looks at the request, he can click the button freeze to change the status of the request to frozen, and the button then can no longer be clicked. 
![Screenshot 2025-04-21 143254](https://github.com/user-attachments/assets/0a5c354d-a996-464f-a0d0-c7ccabe39b6e)
![Screenshot 2025-04-21 143329](https://github.com/user-attachments/assets/9f98f788-b5d6-4d19-a4d3-9e7e774b7419)
![viber_image_2025-04-21_16-19-00-582](https://gi
![viber_image_2025-04-22_09-43-13-503](https://github.com/user-attachments/assets/707516c8-6db0-489a-9565-5a3f8d280a23)
thub.com/user-attachments/assets/c5ed8853-834a-4037-8e60-b292265e1a39)
![viber_image_2025-04-22_10-44-12-337](https://github.com/user-attachments/assets/e1fd4830-658a-4b6a-9a45-c9a2acb90a6f)
![viber_image_2025-04-21_14-43-36-932](https://github.com/user-attachments/assets/3da89cea-654a-48ea-8169-31475daf96b4)
