### PR TITLE
fix(seller-procurement-requests): create bid button disabled for appropriate requests

### DIFF
--- a/src/components/Cards/ProcurementRequestCard.jsx
+++ b/src/components/Cards/ProcurementRequestCard.jsx
@@ -8,8 +8,11 @@ const ProcurementRequestCard = ({
   request,
   followedRequests,
   setFollowedRequests,
+  submittedBidRequestIds=[],
 }) => {
   const navigate = useNavigate();
+
+  const isBidSubmitted = submittedBidRequestIds.includes(request.id);
 
   const handleFollowClick = async (requestId) => {
     const isFollowed = followedRequests[requestId] || false;
@@ -34,6 +37,7 @@ const ProcurementRequestCard = ({
         <div style={{ display: "flex", gap: "1rem" }}>
           <PrimaryButton
             onClick={() => handleCreateBidProposalClick(request.id)}
+            disabled={isBidSubmitted}
           >
             Create Bid Proposal
           </PrimaryButton>

--- a/src/pages/SellerDashboardRequests.jsx
+++ b/src/pages/SellerDashboardRequests.jsx
@@ -29,7 +29,21 @@ const SellerDashboardRequests = () => {
     const [budgetMin, setBudgetMin] = useState();
     const [budgetMax, setBudgetMax] = useState();
     const [followedRequests, setFollowedRequests] = useState({});
+    
+    const [submittedBidRequestIds, setSubmittedBidRequestIds] = useState([]);
 
+    const fetchSubmittedBidRequestIds = async () => {
+        try {
+            const response = await axios.get(`${import.meta.env.VITE_API_URL}/api/bids/request-ids`, {
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                }
+            });
+            setSubmittedBidRequestIds(response.data.requestIds);
+        } catch (error) {
+            console.error('Error fetching submitted bid request IDs:', error);
+        }
+    };
     const fetchBuyerTypes = async () => {
         try {
             const response = await axios.get(
@@ -87,6 +101,7 @@ const SellerDashboardRequests = () => {
         fetchBuyerTypes();
         fetchCategories();
         fetchRequests();
+        fetchSubmittedBidRequestIds();
       
         const loadFavorites = async () => {
           const favorites = await fetchFavorites();
@@ -195,6 +210,7 @@ const SellerDashboardRequests = () => {
                                         request={request}
                                         followedRequests={followedRequests}
                                         setFollowedRequests={setFollowedRequests}
+                                        submittedBidRequestIds={submittedBidRequestIds}
                                     />
                                 ))}
                             </div>

--- a/src/pages/SellerFavorites.jsx
+++ b/src/pages/SellerFavorites.jsx
@@ -1,17 +1,20 @@
 import React, { useEffect, useState } from "react";
 import ProcurementRequestCard from "../components/Cards/ProcurementRequestCard";
-import { fetchFavorites } from "../utils/favorites";
+import { fetchFavorites, fetchSubmittedBidRequestIds } from "../utils/favorites";
 import Layout from "../components/Layout/Layout";
 import "../styles/SellerDashboardRequests.css";
 
 const SellerFavorites = () => {
   const [favorites, setFavorites] = useState([]);
   const [followedRequests, setFollowedRequests] = useState({});
-
+  const [submittedBidRequestIds, setSubmittedBidRequestIds] = useState([]);
+  
   useEffect(() => {
     const fetchData = async () => {
       const data = await fetchFavorites();
       setFavorites(data);
+      const ids = await fetchSubmittedBidRequestIds();
+      setSubmittedBidRequestIds(ids);
       console.log(data);
       const initialFollowed = {};
       data.forEach((req) => {
@@ -39,6 +42,7 @@ const SellerFavorites = () => {
               request={request}
               followedRequests={followedRequests}
               setFollowedRequests={setFollowedRequests}
+              submittedBidRequestIds={submittedBidRequestIds}
             />
           ))
         )}

--- a/src/utils/favorites.jsx
+++ b/src/utils/favorites.jsx
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
 const API_URL = `${import.meta.env.VITE_API_URL}/api`;
+const token = localStorage.getItem("token");
 
 export const toggleFollowRequest = async (requestId, currentFollowedState, setFollowedState) => {
-    const token = localStorage.getItem("token");
 
     try {
         const method = currentFollowedState ? 'delete' : 'post';
@@ -26,7 +26,6 @@ export const toggleFollowRequest = async (requestId, currentFollowedState, setFo
 };
 
 export const fetchFavorites = async () => {
-    const token = localStorage.getItem("token");
 
     try {
         const res = await axios.get(`${API_URL}/procurement-requests/favorites`, {
@@ -34,11 +33,26 @@ export const fetchFavorites = async () => {
                 Authorization: `Bearer ${token}`,
             },
         });
-        console.log("iz favorites.jsx" ,res.data);
 
-        return res.data;
+        const activeFavorites = res.data.filter(item => item.status === "active");
+        
+        return activeFavorites;
     } catch (error) {
         console.error("Error fetching favorites:", error);
         return [];
     }
 };
+
+export const fetchSubmittedBidRequestIds = async () => {
+    try {
+        const response = await axios.get(`${import.meta.env.VITE_API_URL}/api/bids/request-ids`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            }
+        });
+        return response.data.requestIds;
+    } catch (error) {
+        console.error('Error fetching submitted bid request IDs:', error);
+    }
+};
+


### PR DESCRIPTION
Fixes:

- Create Bid Proposal button is now disabled for procurement requests where the seller has already submitted a bid.
- Favorites filtering: only procurement requests with status active are returned.
<img width="1417" alt="Screenshot 2025-05-09 at 1 10 40 PM" src="https://github.com/user-attachments/assets/b2a19e1f-535a-4d23-8a6f-2e3169dbb5e5" />
<img width="1430" alt="Screenshot 2025-05-09 at 1 10 52 PM" src="https://github.com/user-attachments/assets/3a6298b7-d481-41da-aa8a-267b435441b4" />
